### PR TITLE
Implement data sandboxing by user

### DIFF
--- a/api/src/auth/authenticate.ts
+++ b/api/src/auth/authenticate.ts
@@ -4,7 +4,8 @@ import { User } from "../types/user"
 import { users } from "../constants/users"
 import { omit } from "lodash"
 
-const findUserByEmail = (email: string) => users.find((u) => u.email === email)
+export const findUserByEmail = (email: string) =>
+  users.find((u) => u.email === email)
 
 export async function authenticate(
   email: string,

--- a/api/src/auth/sign.ts
+++ b/api/src/auth/sign.ts
@@ -10,6 +10,7 @@ export const signUserToken = (user: User): string =>
       first_name: user.firstName,
       last_name: user.lastName,
       groups: [user.group],
+      shop_id: user.shopId,
       exp: Math.round(Date.now() / 1000) + 60 * 0.25, // 1.1 minute expiration
     },
     METABASE_JWT_SHARED_SECRET,

--- a/api/src/constants/errors.ts
+++ b/api/src/constants/errors.ts
@@ -1,5 +1,5 @@
 import { METABASE_INSTANCE_URL } from "./env"
 
-export const LOGIN_FAILED_MESSAGE = `incorrect credentials. please use email "rene@example.com" or "cecilia@example.com" with password "password".`
+export const LOGIN_FAILED_MESSAGE = `incorrect credentials. please use email "rene@example.com", "cecilia@example.com" or "emily@example.com" with password "password".`
 
 export const SSO_NOT_CONFIGURED_MESSAGE = `please configure JWT authentication in metabase at ${METABASE_INSTANCE_URL}/admin/settings/authentication/jwt to enable logins. refer to https://www.metabase.com/docs/latest/embedding/interactive-embedding-quick-start-guide.html for more information.`

--- a/api/src/constants/users.ts
+++ b/api/src/constants/users.ts
@@ -22,4 +22,12 @@ export const users: User[] = [
     hash: DEMO_PASSWORD_HASH,
     shopId: 2,
   },
+  {
+    firstName: "Emily",
+    lastName: "Johnson",
+    email: "emily@example.com",
+    group: SHOP_ADMIN_GROUP,
+    hash: DEMO_PASSWORD_HASH,
+    shopId: 3,
+  },
 ]

--- a/api/src/constants/users.ts
+++ b/api/src/constants/users.ts
@@ -3,12 +3,14 @@ import { User } from "../types/user"
 /** Hash of the "password" password, used for the demo. */
 const DEMO_PASSWORD_HASH = `$argon2id$v=19$m=65536,t=3,p=4$SPxNs6dPuj0kL0HV/Q+EaQ$sxUyyap4NFEDweTLJZaoLbuVGZGTD297Dz+Hh3Jvahs`
 
+const SHOP_ADMIN_GROUP = "Shop Admin"
+
 export const users: User[] = [
   {
     firstName: "Rene",
     lastName: "Mueller",
     email: "rene@example.com",
-    group: "Charlie",
+    group: SHOP_ADMIN_GROUP,
     hash: DEMO_PASSWORD_HASH,
     shopId: 1,
   },
@@ -16,7 +18,7 @@ export const users: User[] = [
     firstName: "Cecilia",
     lastName: "Stark",
     email: "cecilia@example.com",
-    group: "Delta",
+    group: SHOP_ADMIN_GROUP,
     hash: DEMO_PASSWORD_HASH,
     shopId: 2,
   },

--- a/api/src/constants/users.ts
+++ b/api/src/constants/users.ts
@@ -10,6 +10,7 @@ export const users: User[] = [
     email: "rene@example.com",
     group: "Charlie",
     hash: DEMO_PASSWORD_HASH,
+    shopId: 1,
   },
   {
     firstName: "Cecilia",
@@ -17,5 +18,6 @@ export const users: User[] = [
     email: "cecilia@example.com",
     group: "Delta",
     hash: DEMO_PASSWORD_HASH,
+    shopId: 2,
   },
 ]

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -20,7 +20,7 @@ router.get("/", (_, res) => res.send({ status: "ok" }))
 router.post("/login", loginHandler)
 router.post("/logout", logoutHandler)
 router.get("/sso/metabase", metabaseAuthHandler)
-router.get("/products", productListHandler)
+router.get("/products", restrict, productListHandler)
 router.get("/product/:id", productDetailHandler)
 router.get("/user", restrict, (req: any, res: any) => {
   res.status(200).json({ user: req.session.user })

--- a/api/src/routes/product-list.ts
+++ b/api/src/routes/product-list.ts
@@ -1,8 +1,16 @@
 import { Request, Response } from "express"
 
 import { db } from "../utils/db"
+import { findUserByEmail } from "../auth/authenticate"
 
 export async function productListHandler(req: Request, res: Response) {
+  // user is guaranteed to be defined by the restrict middleware
+  const user = findUserByEmail(req.session.user!.email)
+
+  if (!user?.shopId) {
+    return res.status(400).json({ error: "user has no assigned shop" })
+  }
+
   try {
     const products = await db.query.products.findMany({
       columns: {
@@ -12,6 +20,7 @@ export async function productListHandler(req: Request, res: Response) {
         imageUrl: true,
       },
       with: { category: { columns: { name: true } } },
+      where: (products, { eq }) => eq(products.shopId, user.shopId),
     })
 
     res.status(200).json({ products })

--- a/api/src/types/user.ts
+++ b/api/src/types/user.ts
@@ -3,6 +3,7 @@ export interface User {
   firstName: string
   lastName: string
   group: string
+  shopId: number
 
   hash?: string
   exp?: number

--- a/src/routes/Login.tsx
+++ b/src/routes/Login.tsx
@@ -24,6 +24,7 @@ export function Login() {
     async mutationFn(values: LoginValues) {
       await login(values)
       await queryClient.refetchQueries({ queryKey: ["auth"] })
+      await queryClient.refetchQueries({ queryKey: ["products"] })
     },
   })
 

--- a/src/routes/Login.tsx
+++ b/src/routes/Login.tsx
@@ -16,7 +16,7 @@ export function Login() {
       email: (value) =>
         value.endsWith("@example.com")
           ? null
-          : "invalid email. use rene@example.com or cecilia@example.com",
+          : "invalid email. use rene@example.com, cecilia@example.com or emily@example.com",
     },
   })
 
@@ -86,8 +86,8 @@ export function Login() {
 
         <Box>
           <Text size="xs">
-            use "rene@example.com" or "cecilia@example.com" as the email, and
-            "password" as the password.
+            use "rene@example.com", "cecilia@example.com" or "emily@example.com"
+            as the email, and "password" as the password.
           </Text>
         </Box>
       </Flex>

--- a/src/routes/Logout.tsx
+++ b/src/routes/Logout.tsx
@@ -9,7 +9,12 @@ import { queryClient } from "../utils/query-client"
 export function Logout() {
   const logoutMutation = useMutation({
     mutationFn: logout,
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["auth"] }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["auth"] })
+
+      // Workaround: force a full page reload to reset the MetabaseProvider state
+      window.location.href = "/"
+    },
   })
 
   const { mutate } = logoutMutation
@@ -24,10 +29,6 @@ export function Logout() {
         <Box>{logoutMutation.error.message}</Box>
       </Box>
     )
-  }
-
-  if (logoutMutation.isSuccess) {
-    return <Redirect to="/login" />
   }
 
   return (

--- a/src/utils/query-product.ts
+++ b/src/utils/query-product.ts
@@ -4,6 +4,7 @@ import { Product } from "../types/product"
 export async function getProductList(): Promise<Product[]> {
   const response = await fetch(`${API_HOST}/products`, {
     method: "GET",
+    credentials: "include",
   })
 
   const { products } = (await response.json()) as { products: Product[] }


### PR DESCRIPTION
Closes #27 

### How to test this?

Note that this is currently tricky to test because we are sharing the same MB instance for testing with production, so user groups will get overwritten if someone visits the Vercel deployment right now.

- Login to the Shoppy MB instance with your @metabase.com email. Go to admin settings > users. Verify that Rene and Cecilia are part of the "Shop Admin" group, which has "shop_id" and "groups" user attributes set to 1/2 and "Shop Admin" respectively.
  - If not, it likely got overridden due to folks visiting the Vercel production. Please set Rene and Cecilia's group to "Shop Admin" manually for testing - it should be synced automatically, unless it's overwritten by the old groups from the production environment. 
  - <img src="https://github.com/metabase/shoppy/assets/4714175/ba7eb49b-9f2a-449d-afcc-e03e2c8e7511" width="300">

- Run the Shoppy app locally. Make sure to run both the demo JWT server and the React app as usual. You must use the JWT server from this branch!
- Login with rene@example.com.
- You should see the products be a little bit different than usual. It is now filtered by `shop_id`
- Note the trend numbers. Click on a product card. Note the numbers. Click on analytics. Note some numbers.
- Logout and login with cecilia@example.com.
- Again, notice that the products and numbers are different when you click around, compared to Rene's shop.

### Caveat

- There are some viz that will says "no data" because there is not enough data from some shop after sandboxing, I'm fixing that in the MB instance.