### PR TITLE
Add a script for reconciling shop_id across entities in demo data

### DIFF
--- a/api/drizzle/seeder/assign-shops.ts
+++ b/api/drizzle/seeder/assign-shops.ts
@@ -1,0 +1,59 @@
+import { eq } from "drizzle-orm"
+
+import { db } from "../../src/utils/db"
+import { products as productSchema } from "../../src/schema/products"
+import { people as peopleSchema } from "../../src/schema/people"
+import { orders as orderSchema } from "../../src/schema/orders"
+
+/**
+ * Assign shop_id to products based on their product category.
+ */
+export async function assignShopsToProducts() {
+  const products = await db.query.products.findMany({
+    columns: { id: true, categoryId: true },
+    with: { category: true },
+  })
+
+  for (const product of products) {
+    const { shopId } = product.category ?? {}
+
+    await db
+      .update(productSchema)
+      .set({ shopId })
+      .where(eq(productSchema.id, product.id))
+      .returning()
+  }
+}
+
+/**
+ * Assign shop_id to customers based on their purchased product.
+ */
+export async function assignShopsToCustomers() {
+  const customers = await db.query.people.findMany({
+    columns: { id: true },
+  })
+
+  for (const customer of customers) {
+    const orders = await db.query.orders.findMany({
+      columns: { id: true, productId: true },
+      where: eq(orderSchema.customerId, customer.id),
+    })
+
+    for (const order of orders) {
+      if (!order.productId) continue
+
+      const product = await db.query.products.findFirst({
+        columns: { id: true, shopId: true },
+        where: eq(productSchema.id, order.productId),
+      })
+
+      if (product) {
+        await db
+          .update(peopleSchema)
+          .set({ shopId: product.shopId })
+          .where(eq(peopleSchema.id, customer.id))
+          .returning()
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds a one-time and quick-and-dirty script that reconciles the shop_id with products and customers table.

PS. This script has already been ran against all demo data. This is purely for future reference and likely will never be ran again, unless we seeded more data and it goes out-of-sync again for some reason.