### PR TITLE
Update vercel rewrites to fix 404 on page reload

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,6 +4,10 @@
     {
       "source": "/api/:path*",
       "destination": "/api/src/main"
+    },
+    {
+      "source": "/(.*)",
+      "destination": "/"
     }
   ]
 }


### PR DESCRIPTION
Updates the vercel.json rewrite configuration to fix the "404 not found" issue.

## How to reproduce

You can test this change on https://metabase-shoppy.vercel.app as it has been hot-fixed there.

- Go to Vercel deployments
- Login
- Reload the page
- There should not be a 404 error.