### PR TITLE
Replace `theme` with `site` to fix runtime errors

### DIFF
--- a/src/components/FontLoader.tsx
+++ b/src/components/FontLoader.tsx
@@ -6,6 +6,6 @@ export function FontLoader() {
   const [site] = useAtom(siteAtom)
 
   return (
-    <link type="text/css" rel="stylesheet" href={`/fonts/${theme}.font.css`} />
+    <link type="text/css" rel="stylesheet" href={`/fonts/${site}.font.css`} />
   )
 }

--- a/src/components/SdkStates.tsx
+++ b/src/components/SdkStates.tsx
@@ -10,7 +10,7 @@ export const MetabaseLoader = () => {
     <Flex
       h="100%"
       align="center"
-      {...(theme === "stitch"
+      {...(site === "stitch"
         ? { ml: "8px", justify: "flex-start" }
         : { justify: "center" })}
     >

--- a/src/components/SiteLogo.tsx
+++ b/src/components/SiteLogo.tsx
@@ -6,15 +6,15 @@ import { siteAtom } from "../store/site"
 export function SiteLogo() {
   const [site] = useAtom(siteAtom)
 
-  if (theme === "luminara") {
+  if (site === "luminara") {
     return <Image src="/logo-luminara.svg" />
   }
 
-  if (theme === "pug") {
+  if (site === "pug") {
     return <Image src="/logo-pug-n-play.png" w="160px" />
   }
 
-  if (theme === "stitch") {
+  if (site === "stitch") {
     return (
       <Text
         fw={200}

--- a/src/routes/product-list/ProductCard.tsx
+++ b/src/routes/product-list/ProductCard.tsx
@@ -18,7 +18,7 @@ export const ProductCard = ({ product }: Props) => {
   const [site] = useAtom(siteAtom)
   const image = product.imageUrl ?? "/mock-t-shirt.webp"
 
-  const questionHeight = theme === "stitch" ? 40 : 70
+  const questionHeight = site === "stitch" ? 40 : 70
 
   return (
     <Link href={`/products/${product.id}`}>

--- a/src/routes/product-list/ProductCardFooter.tsx
+++ b/src/routes/product-list/ProductCardFooter.tsx
@@ -6,7 +6,7 @@ import { siteAtom } from "../../store/site"
 export function ProductCardFooter() {
   const [site] = useAtom(siteAtom)
 
-  if (theme === "luminara") {
+  if (site === "luminara") {
     return (
       <Box w="100%">
         <Divider mx={16} className="divider" />


### PR DESCRIPTION
Looks like the build process does not validate non-existent variables, and my IDE accidentally misreplaced some variables that caused the page to crash. 😓 This is already fixed in the release branch, but backported to `main`.

# How to test

Visit https://metabase-shoppy.vercel.app (it's already fixed there) or run this locally.