### PR TITLE
Remove CSS workaround for popover z-index

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@mantine/core": "^7.8.0",
     "@mantine/form": "^7.8.0",
     "@mantine/hooks": "^7.8.0",
-    "@metabase/embedding-sdk-react": "^0.1.19",
+    "@metabase/embedding-sdk-react": "0.1.20",
     "@tanstack/react-query": "^5.32.0",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@mantine/core": "^7.8.0",
     "@mantine/form": "^7.8.0",
     "@mantine/hooks": "^7.8.0",
-    "@metabase/embedding-sdk-react": "0.1.20",
+    "@metabase/embedding-sdk-react": "0.1.21",
     "@tanstack/react-query": "^5.32.0",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",

--- a/src/styles/dashboard-workaround.css
+++ b/src/styles/dashboard-workaround.css
@@ -1,8 +1,3 @@
-/** WORKAROUND: Allows popovers to work when rendered under Mantine modals */
-[data-tippy-root]:has(.tippy-box.popover) {
-  z-index: 201 !important;
-}
-
 .dashboard-container [data-testid="legend-caption-title"] {
   font-size: 17px;
   line-height: 20px;

--- a/src/themes/luminara.ts
+++ b/src/themes/luminara.ts
@@ -61,11 +61,14 @@ const metabase: MetabaseTheme = {
     dashboard: {
       backgroundColor: "transparent",
     },
-    scalar: {
+    number: {
       value: {
         fontSize: "36px",
         lineHeight: "36px",
       },
+    },
+    popover: {
+      zIndex: 201,
     },
   },
 }

--- a/src/themes/pug.ts
+++ b/src/themes/pug.ts
@@ -64,11 +64,14 @@ const metabase: MetabaseTheme = {
         border: "none",
       },
     },
-    scalar: {
+    number: {
       value: {
         fontSize: "24px",
         lineHeight: "30px",
       },
+    },
+    popover: {
+      zIndex: 201,
     },
   },
 }

--- a/src/themes/stitch.ts
+++ b/src/themes/stitch.ts
@@ -63,11 +63,14 @@ const metabase: MetabaseTheme = {
         backgroundColor: "#212426",
       },
     },
-    scalar: {
+    number: {
       value: {
         fontSize: "18px",
         lineHeight: "22px",
       },
+    },
+    popover: {
+      zIndex: 201,
     },
   },
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -945,10 +945,10 @@
   resolved "https://registry.yarnpkg.com/@mantine/utils/-/utils-6.0.21.tgz#6185506e91cba3e308aaa8ea9ababc8e767995d6"
   integrity sha512-33RVDRop5jiWFao3HKd3Yp7A9mEq4HAJxJPTuYm1NkdqX6aTKOQK7wT8v8itVodBp+sb4cJK6ZVdD1UurK/txQ==
 
-"@metabase/embedding-sdk-react@0.1.20":
-  version "0.1.20"
-  resolved "https://registry.yarnpkg.com/@metabase/embedding-sdk-react/-/embedding-sdk-react-0.1.20.tgz#481b9ab19bd5c585f6e5fe897bdca0a60538b656"
-  integrity sha512-hSx3xQn1w6EWsmIrn3u4EOLWH4riOTWKzU+kjr6SZG90uT3PWQIaxal2Eg6VfIbhEhb8YUBgtB945kwxTqUYdQ==
+"@metabase/embedding-sdk-react@0.1.21":
+  version "0.1.21"
+  resolved "https://registry.yarnpkg.com/@metabase/embedding-sdk-react/-/embedding-sdk-react-0.1.21.tgz#5ebff943d0f54791f43c854edb1fe6648bd728e4"
+  integrity sha512-7LaOwUHpKbEwQ58J3jaK2oFsRnaiyUZypqZDrrbp0uho5YM3oya3/i8Ik+U4YhcaXtyIG1zRtgXj27lgAHYjBg==
   dependencies:
     "@dnd-kit/core" "^6.0.8"
     "@dnd-kit/modifiers" "^6.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -945,10 +945,10 @@
   resolved "https://registry.yarnpkg.com/@mantine/utils/-/utils-6.0.21.tgz#6185506e91cba3e308aaa8ea9ababc8e767995d6"
   integrity sha512-33RVDRop5jiWFao3HKd3Yp7A9mEq4HAJxJPTuYm1NkdqX6aTKOQK7wT8v8itVodBp+sb4cJK6ZVdD1UurK/txQ==
 
-"@metabase/embedding-sdk-react@^0.1.19":
-  version "0.1.19"
-  resolved "https://registry.yarnpkg.com/@metabase/embedding-sdk-react/-/embedding-sdk-react-0.1.19.tgz#a45fc0c7387c68790df2b82eb169d739bb4b67d5"
-  integrity sha512-HeEm4zJgVgjpE6SB/qUfwQ3UaGM01gK8IazJnemFqMJ9zH3OwaEQn05+QQy4B6bh46OAgFdypKcAjw3/9K56VA==
+"@metabase/embedding-sdk-react@0.1.20":
+  version "0.1.20"
+  resolved "https://registry.yarnpkg.com/@metabase/embedding-sdk-react/-/embedding-sdk-react-0.1.20.tgz#481b9ab19bd5c585f6e5fe897bdca0a60538b656"
+  integrity sha512-hSx3xQn1w6EWsmIrn3u4EOLWH4riOTWKzU+kjr6SZG90uT3PWQIaxal2Eg6VfIbhEhb8YUBgtB945kwxTqUYdQ==
   dependencies:
     "@dnd-kit/core" "^6.0.8"
     "@dnd-kit/modifiers" "^6.0.1"


### PR DESCRIPTION
Removes the CSS workaround used for adjusting the popover's z-index. Requires https://github.com/metabase/metabase/pull/45613 to be merged and released first.

![CleanShot 2567-07-16 at 21 37 32@2x](https://github.com/user-attachments/assets/7b22a0f7-8338-4367-85cf-fd4f7971c2d2)
