### PR TITLE
Smoothens the wave sidebar in Pug & Play and bump to v0.1.22

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@mantine/core": "^7.8.0",
     "@mantine/form": "^7.8.0",
     "@mantine/hooks": "^7.8.0",
-    "@metabase/embedding-sdk-react": "0.1.21",
+    "@metabase/embedding-sdk-react": "^0.1.22",
     "@tanstack/react-query": "^5.32.0",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",

--- a/src/routes/product-list/ProductCard.tsx
+++ b/src/routes/product-list/ProductCard.tsx
@@ -20,6 +20,7 @@ export const ProductCard = ({ product }: Props) => {
   const image = product.imageUrl ?? "/mock-t-shirt.webp"
 
   const questionHeight = site === "stitch" ? 40 : 70
+  const truncateLength = site === "pug" ? 13 : 50
 
   return (
     <Link href={`/products/${product.id}`}>
@@ -29,7 +30,7 @@ export const ProductCard = ({ product }: Props) => {
 
           <Stack className="smartscalar product-card-trend" mih={70} gap={0}>
             <Text className="product-card-title" pl="8px">
-              {truncate(product.title, 13)}
+              {truncate(product.title, truncateLength)}
             </Text>
 
             <Box py={4} mih={questionHeight}>

--- a/src/themes/pug.css
+++ b/src/themes/pug.css
@@ -29,9 +29,10 @@ body[data-theme="pug"] {
     content: " ";
     background: url(/blue-sidebar-waves.svg);
     background-repeat: repeat-y;
+    background-position: center;
     height: 100%;
-    width: 20px;
-    right: -12px;
+    width: 23px;
+    right: -11px;
   }
 
   .sidebar-inactive-child {

--- a/yarn.lock
+++ b/yarn.lock
@@ -945,10 +945,10 @@
   resolved "https://registry.yarnpkg.com/@mantine/utils/-/utils-6.0.21.tgz#6185506e91cba3e308aaa8ea9ababc8e767995d6"
   integrity sha512-33RVDRop5jiWFao3HKd3Yp7A9mEq4HAJxJPTuYm1NkdqX6aTKOQK7wT8v8itVodBp+sb4cJK6ZVdD1UurK/txQ==
 
-"@metabase/embedding-sdk-react@0.1.21":
-  version "0.1.21"
-  resolved "https://registry.yarnpkg.com/@metabase/embedding-sdk-react/-/embedding-sdk-react-0.1.21.tgz#5ebff943d0f54791f43c854edb1fe6648bd728e4"
-  integrity sha512-7LaOwUHpKbEwQ58J3jaK2oFsRnaiyUZypqZDrrbp0uho5YM3oya3/i8Ik+U4YhcaXtyIG1zRtgXj27lgAHYjBg==
+"@metabase/embedding-sdk-react@^0.1.22":
+  version "0.1.22"
+  resolved "https://registry.yarnpkg.com/@metabase/embedding-sdk-react/-/embedding-sdk-react-0.1.22.tgz#43045f19e55b2a95cb5bd6256232ad086a0480ae"
+  integrity sha512-O7T+9Wcl/u7YdXmFtNlrFlxm5GpEGfFROd3FjFo5wW+Vex0vXakpezWLTAqlagWzSOGWZBNWd0NQ5/vwSX+86w==
   dependencies:
     "@dnd-kit/core" "^6.0.8"
     "@dnd-kit/modifiers" "^6.0.1"


### PR DESCRIPTION
Smoothens the wave decoration in the sidebar in the pug and play theme.

NOTE: the bad foreground color is an SDK issue, it will be fixed by https://github.com/metabase/metabase/pull/45859, out of scope of this PR.

![CleanShot 2567-07-19 at 23 13 45@2x](https://github.com/user-attachments/assets/ab83a326-36cb-4bb1-8a39-09c0912e0ebc)
