### PR TITLE
Bump embedding sdk version to v0.1.23 to fix foreground text issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@mantine/core": "^7.8.0",
     "@mantine/form": "^7.8.0",
     "@mantine/hooks": "^7.8.0",
-    "@metabase/embedding-sdk-react": "^0.1.22",
+    "@metabase/embedding-sdk-react": "0.1.23",
     "@tanstack/react-query": "^5.32.0",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -945,10 +945,10 @@
   resolved "https://registry.yarnpkg.com/@mantine/utils/-/utils-6.0.21.tgz#6185506e91cba3e308aaa8ea9ababc8e767995d6"
   integrity sha512-33RVDRop5jiWFao3HKd3Yp7A9mEq4HAJxJPTuYm1NkdqX6aTKOQK7wT8v8itVodBp+sb4cJK6ZVdD1UurK/txQ==
 
-"@metabase/embedding-sdk-react@^0.1.22":
-  version "0.1.22"
-  resolved "https://registry.yarnpkg.com/@metabase/embedding-sdk-react/-/embedding-sdk-react-0.1.22.tgz#43045f19e55b2a95cb5bd6256232ad086a0480ae"
-  integrity sha512-O7T+9Wcl/u7YdXmFtNlrFlxm5GpEGfFROd3FjFo5wW+Vex0vXakpezWLTAqlagWzSOGWZBNWd0NQ5/vwSX+86w==
+"@metabase/embedding-sdk-react@0.1.23":
+  version "0.1.23"
+  resolved "https://registry.yarnpkg.com/@metabase/embedding-sdk-react/-/embedding-sdk-react-0.1.23.tgz#8400b7c0d823117d16a79c4d4a9cc673acdeb7ca"
+  integrity sha512-o8kvXPtQZrEKMZ035Sa6p7/Ui/7nc6oORTt9RlxlFSxNFteo/OhEUjcQW5LYpNnf7VYWYNmIw1yCcdx5QqqJCA==
   dependencies:
     "@dnd-kit/core" "^6.0.8"
     "@dnd-kit/modifiers" "^6.0.1"


### PR DESCRIPTION
Bump embedding sdk version to v0.1.23 to fix foreground text issue