### PR TITLE
Increase interactive question height in modal

### DIFF
--- a/src/routes/product-detail/ProductDetailInsights.tsx
+++ b/src/routes/product-detail/ProductDetailInsights.tsx
@@ -58,7 +58,7 @@ export const ProductDetailInsights = (props: Props) => {
       >
         <InteractiveQuestion
           questionId={158}
-          height={500}
+          height={700}
           withTitle
           customTitle={
             <Title fw={400} size="h2" className="product-detail-card-title">


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/46825

Increases the interactive question height in the Shoppy demo, so that it shows more content in a modal.

(Note: this issue is quite specific to Shoppy modals - our SDK components already supports `height="100%"`)

![CleanShot 2567-08-22 at 20 48 00@2x](https://github.com/user-attachments/assets/daf51d74-2c51-412b-b3fd-1c85fb4fb848)
