### PR TITLE
Allow metabase.com and vercel.app to access Shoppy APIs

### DIFF
--- a/api/src/constants/env.ts
+++ b/api/src/constants/env.ts
@@ -13,9 +13,4 @@ export const FRONTEND_URL = process.env.FRONTEND_URL ?? "http://localhost:3004"
 
 export const SESSION_SECRET = process.env.SESSION_SECRET
 
-export const {
-  VERCEL_ENV,
-  VERCEL_URL,
-  VERCEL_BRANCH_URL,
-  VERCEL_PROJECT_PRODUCTION_URL,
-} = process.env
+export const { VERCEL_ENV } = process.env

--- a/api/src/middleware/index.ts
+++ b/api/src/middleware/index.ts
@@ -7,8 +7,7 @@ import { FRONTEND_URL, SESSION_SECRET, VERCEL_ENV } from "../constants/env"
 import { pg } from "../utils/db"
 
 // Allow these origins to access the mock API server.
-const isWhitelistedOrigin = (origin?: string) =>
-  !origin ||
+const isWhitelistedOrigin = (origin: string) =>
   origin.includes("localhost") ||
   origin.includes("vercel.app") ||
   origin.includes("metabase.com") ||
@@ -21,11 +20,8 @@ export function setupMiddleware(app: Express) {
 
   const corsMiddleware = cors({
     origin: (origin, callback) => {
-      if (isWhitelistedOrigin(origin)) {
-        return callback(null, true)
-      }
-
-      callback(new Error("cross-origin request not allowed"))
+      // Return the CORS header if the origin is defined in header and whitelisted.
+      callback(null, origin && isWhitelistedOrigin(origin))
     },
     credentials: true,
   })

--- a/api/src/middleware/index.ts
+++ b/api/src/middleware/index.ts
@@ -6,26 +6,22 @@ import pgSessionStore from "connect-pg-simple"
 import { FRONTEND_URL, SESSION_SECRET, VERCEL_ENV } from "../constants/env"
 import { pg } from "../utils/db"
 
+// Allow these origins to access the mock API server.
+const isWhitelistedOrigin = (origin?: string) =>
+  !origin ||
+  origin.includes("localhost") ||
+  origin.includes("vercel.app") ||
+  origin.includes("metabase.com") ||
+  origin.includes(FRONTEND_URL)
+
 export function setupMiddleware(app: Express) {
   const isHosted = !!VERCEL_ENV
 
   const SessionStore = pgSessionStore(session)
 
-  const origins = [
-    FRONTEND_URL,
-
-    // For developing locally with the production api.
-    "http://localhost:3004",
-    "https://localhost:3004",
-  ].filter((url) => url) as string[]
-
   const corsMiddleware = cors({
     origin: (origin, callback) => {
-      if (
-        !origin ||
-        origin.includes("vercel.app") ||
-        origins.includes(origin)
-      ) {
+      if (isWhitelistedOrigin(origin)) {
         return callback(null, true)
       }
 


### PR DESCRIPTION
Allow metabase.com and vercel.app to access Shoppy APIs for the hosted demos and deploy previews.

This is to allow https://embedded-analytics-sdk-demo.metabase.com/ and Vercel deploy previews to access the API on the mock server.