### PR TITLE
hotfix: keep the theme in sync with user cookie for people who have previously visited demo

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -26,10 +26,10 @@ import "./styles/viz-workaround.css"
 
 import { store } from "./store"
 
-import { setInitialSiteCookie } from "./utils/switch-site"
+import { syncInitialSiteCookie } from "./utils/switch-site"
 import { ThemeProvider } from "./components/ThemeProvider"
 
-setInitialSiteCookie()
+syncInitialSiteCookie()
 
 const root = document.getElementById("root")!
 

--- a/src/utils/switch-site.ts
+++ b/src/utils/switch-site.ts
@@ -3,7 +3,7 @@ import Cookies from "js-cookie"
 import { queryClient } from "./query-client"
 
 import { SiteKey } from "../types/site"
-import { DEFAULT_SITE, siteAtom } from "../store/site"
+import { DEFAULT_SITE, SITE_KEY, siteAtom } from "../store/site"
 
 import { store } from "../store"
 
@@ -20,7 +20,13 @@ export const setSiteCookie = (site: SiteKey) =>
 
 /** Set the initial site if the demo is visited for the first time. */
 export function setInitialSiteCookie() {
-  if (!Cookies.get(COOKIE_USER_KEY)) setSiteCookie(DEFAULT_SITE)
+  if (!Cookies.get(COOKIE_USER_KEY)) {
+    // Use the site from localStorage as the initial site.
+    // This is a migration for people who have previously visited the demo.
+    const site = JSON.parse(localStorage.getItem(SITE_KEY)!) || DEFAULT_SITE
+
+    setSiteCookie(site as SiteKey)
+  }
 }
 
 export async function switchSite(site: SiteKey) {

--- a/src/utils/switch-site.ts
+++ b/src/utils/switch-site.ts
@@ -18,15 +18,13 @@ const SITE_TO_EMAIL_MAP: Record<SiteKey, string> = {
 export const setSiteCookie = (site: SiteKey) =>
   Cookies.set(COOKIE_USER_KEY, SITE_TO_EMAIL_MAP[site])
 
-/** Set the initial site if the demo is visited for the first time. */
-export function setInitialSiteCookie() {
-  if (!Cookies.get(COOKIE_USER_KEY)) {
-    // Use the site from localStorage as the initial site.
-    // This is a migration for people who have previously visited the demo.
-    const site = JSON.parse(localStorage.getItem(SITE_KEY)!) || DEFAULT_SITE
+/** Sync the user cookie for the API with the site in localStorage. */
+export function syncInitialSiteCookie() {
+  // Use the site from localStorage as the initial user cookie.
+  // This is a migration for people who have previously visited the demo.
+  const site = JSON.parse(localStorage.getItem(SITE_KEY)!) || DEFAULT_SITE
 
-    setSiteCookie(site as SiteKey)
-  }
+  setSiteCookie(site as SiteKey)
 }
 
 export async function switchSite(site: SiteKey) {


### PR DESCRIPTION
For people who have previously visited the demo, the site can look broken as we set the user cookie for the "stitch" theme by default, even when they are in another theme. This always keeps their user cookie in sync with their current theme when they first load the page, so the page is never in a broken state.

Yes, we could've also used the `cookie` as the single source of truth and get rid of the `localStorage` altogether, as they're redundant given the site maps neatly to a single user - to avoid them being out-of-sync. I might do that in a later PR.

PS. this hotfix is already applied to the release branch.

**How to reproduce**
1. Go to the `main` branch
2. Go to either "Pug" or "Luminara" theme
3. Clear your "user" cookie in your developer tools
4. Now reload the page. It should be in an invalid/wrong state, with wrong product images.

**How to test fixes**
5. Now go to this PR's `hotfix-migrate-initial-site-to-user-cookie` branch
6. Repeat step 2 - 4 again. Now the cookie should always be consistent with the site you are on.