### PR TITLE
fix: do not close the mobile menu when clicking on parent link

### DIFF
--- a/src/components/layout/Shell.tsx
+++ b/src/components/layout/Shell.tsx
@@ -82,7 +82,13 @@ export function Shell(props: Props) {
                 <SiteLogo />
               </Link>
 
-              <SidebarLinks onLinkClick={closeMobileNav} />
+              <SidebarLinks
+                onLinkClick={(link) => {
+                  if (!link.children) {
+                    closeMobileNav()
+                  }
+                }}
+              />
             </Box>
 
             <Flex className="sidebar-icons gap-x-3 py-4">

--- a/src/components/layout/SidebarLinks.tsx
+++ b/src/components/layout/SidebarLinks.tsx
@@ -2,11 +2,11 @@ import cx from "classnames"
 import { Link } from "wouter"
 import { Box, Divider, NavLink } from "@mantine/core"
 
-import { SidebarLink } from "../../types/sidebar-link"
+import type { SidebarLink } from "../../types/sidebar-link"
 import { useSidebarLinks } from "../../utils/sidebar-links"
 
 interface SidebarLinkProps {
-  onLinkClick?: () => void
+  onLinkClick?: (link: SidebarLink) => void
 }
 
 export function SidebarLinks({ onLinkClick }: SidebarLinkProps) {
@@ -21,7 +21,7 @@ export function SidebarLinks({ onLinkClick }: SidebarLinkProps) {
 
 const renderLink = (
   link: SidebarLink,
-  context: { isChild?: boolean; onLinkClick?: () => void },
+  context: { isChild?: boolean; onLinkClick?: (link: SidebarLink) => void },
 ) => {
   const { component: Component } = link
   const { isChild, onLinkClick } = context ?? {}
@@ -48,9 +48,7 @@ const renderLink = (
       href={link.to ?? "#!"}
       onClick={() => {
         link.onClick?.()
-
-        // Closes the mobile menu when a link is clicked.
-        onLinkClick?.()
+        onLinkClick?.(link)
       }}
       classNames={{
         children: "space-y-1",


### PR DESCRIPTION
When clicking on parent links (i.e. Products and Analytics) on mobile, it should only collapse and show the links and not close the mobile menu.

<img src="https://github.com/user-attachments/assets/2df465c3-7695-441d-b4ee-8209174db63b" width="300">

### How to test

- Set the screen to mobile viewport on the `main` branch. Clicking on parent links will close the mobile menu.
- On this branch, the mobile menu stays open.