### PR TITLE
Hide new question and new dashboard button on mobile

### DIFF
--- a/src/routes/analytics/AnalyticsCustomPage.tsx
+++ b/src/routes/analytics/AnalyticsCustomPage.tsx
@@ -25,7 +25,7 @@ export function AnalyticsCustomPage() {
 
   return (
     <Container w="100%" p={20}>
-      <Flex justify="flex-end" gap="xs" pb="xs">
+      <Flex justify="flex-end" gap="xs" pb="xs" className="hide-on-mobile">
         <NewQuestionMenu position="bottom-end">
           <Button>New Question</Button>
         </NewQuestionMenu>


### PR DESCRIPTION
Hides the "new question" and "new dashboard" button on mobile. We already hide those links on the sidebar, as the query builder is not very well-optimized for mobile.

<img src="https://github.com/user-attachments/assets/39636bd5-f1cc-4721-8864-87791da7ddd1" width="200">
