### PR TITLE
Hide PDF downloads on dashboards

### DIFF
--- a/src/routes/analytics/DashboardPage.tsx
+++ b/src/routes/analytics/DashboardPage.tsx
@@ -15,7 +15,11 @@ export function DashboardPage(props: Props) {
 
   return (
     <Box mih="100vh" className="dashboard-container smartscalar">
-      <InteractiveDashboard dashboardId={dashboardId} withTitle withDownloads />
+      <InteractiveDashboard
+        dashboardId={dashboardId}
+        withTitle
+        withDownloads={false}
+      />
     </Box>
   )
 }


### PR DESCRIPTION
PDF downloads looks broken on dashboards when custom themes are applied, especially on the line height. We should hide it from the demo for the time being.