### PR TITLE
Convert `jwtProviderUri` to `authProviderUri`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
 VITE_APP_METABASE_INSTANCE_URL=https://shoppy.hosted.staging.metabase.com
 VITE_APP_API_HOST=https://metabase-shoppy.vercel.app/api
-VITE_APP_JWT_PROVIDER_URI=/sso/metabase
+VITE_APP_AUTH_PROVIDER_URI=/sso/metabase

--- a/src/components/AppProvider.tsx
+++ b/src/components/AppProvider.tsx
@@ -5,7 +5,7 @@ import { MetabaseProvider, type SDKConfig } from "@metabase/embedding-sdk-react"
 
 import {
   API_HOST,
-  JWT_PROVIDER_URI,
+  AUTH_PROVIDER_URI,
   METABASE_INSTANCE_URL,
 } from "../constants/env"
 
@@ -30,11 +30,11 @@ export const AppProvider = ({ children }: Props) => {
   const config: SDKConfig = useMemo(() => {
     return {
       metabaseInstanceUrl: METABASE_INSTANCE_URL,
-      jwtProviderUri: `${API_HOST}${JWT_PROVIDER_URI}`,
+      authProviderUri: `${API_HOST}${AUTH_PROVIDER_URI}`,
       loaderComponent: MetabaseLoader,
       errorComponent: MetabaseError,
 
-      // Append the current site as a query parameter to the JWT provider URL.
+      // Append the current site as a query parameter to the auth provider URL.
       fetchRequestToken: (url: string) =>
         fetch(`${url}?site=${site}`).then((res) => res.json()),
     }

--- a/src/constants/env.ts
+++ b/src/constants/env.ts
@@ -6,8 +6,8 @@
  */
 export const API_HOST = getAPIHost()
 
-export const JWT_PROVIDER_URI =
-  import.meta.env.VITE_APP_JWT_PROVIDER_URI ?? "/sso/metabase"
+export const AUTH_PROVIDER_URI =
+  import.meta.env.VITE_APP_AUTH_PROVIDER_URI ?? "/sso/metabase"
 
 /**
  * URL of the metabase instance.


### PR DESCRIPTION
Changes the `jwtProviderUri` config property to `authProviderUri` to mirror [fix(sdk): Convert jwtProviderUri to authProviderUri](https://github.com/metabase/metabase/pull/49843)