### PR TITLE
Bump SDK version to v0.51.9 to fix crash when clicking on summarize

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@mantine/core": "^7.8.0",
     "@mantine/form": "^7.8.0",
     "@mantine/hooks": "^7.8.0",
-    "@metabase/embedding-sdk-react": "^0.51.8",
+    "@metabase/embedding-sdk-react": "^0.51.9",
     "@tanstack/react-query": "^5.32.0",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1108,10 +1108,10 @@
   resolved "https://registry.yarnpkg.com/@mantine/utils/-/utils-6.0.21.tgz#6185506e91cba3e308aaa8ea9ababc8e767995d6"
   integrity sha512-33RVDRop5jiWFao3HKd3Yp7A9mEq4HAJxJPTuYm1NkdqX6aTKOQK7wT8v8itVodBp+sb4cJK6ZVdD1UurK/txQ==
 
-"@metabase/embedding-sdk-react@^0.51.8":
-  version "0.51.8"
-  resolved "https://registry.yarnpkg.com/@metabase/embedding-sdk-react/-/embedding-sdk-react-0.51.8.tgz#933c3a33c0d1b02348710cfbfe021c1785b3bbd5"
-  integrity sha512-7nMeocQHLAaVldofoKBLkRU/bEPcw+Yo7nb/ySsyA1zOwsNHA4l3nv5uDAkrwoD0IBJ8ttyBNMJnBClXhEtG2w==
+"@metabase/embedding-sdk-react@^0.51.9":
+  version "0.51.9"
+  resolved "https://registry.yarnpkg.com/@metabase/embedding-sdk-react/-/embedding-sdk-react-0.51.9.tgz#87007a1a6cbce76dff5c17bc1bf628e55a15d7d7"
+  integrity sha512-FP6Jf1EwMbrDpZuItgNg13FIkt2bK/FZHmwX3By2q6j2YYqc5bYx40a+6Vk5gPX+HtW88Hxgx/7rb9ZoMCIC3w==
   dependencies:
     "@dnd-kit/core" "^6.0.8"
     "@dnd-kit/modifiers" "^6.0.1"


### PR DESCRIPTION
Bumps SDK version to v0.51.9 to fix crash when clicking on summarize