### PR TITLE
Fix interactive question in modal being cut off

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@mantine/core": "^7.8.0",
     "@mantine/form": "^7.8.0",
     "@mantine/hooks": "^7.8.0",
-    "@metabase/embedding-sdk-react": "^0.51.9",
+    "@metabase/embedding-sdk-react": "^0.51.10",
     "@tanstack/react-query": "^5.32.0",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",

--- a/src/components/InteractiveQuestionView.tsx
+++ b/src/components/InteractiveQuestionView.tsx
@@ -77,7 +77,7 @@ export const InteractiveQuestionView = ({ isSaveEnabled = false }: Props) => {
       </Flex>
 
       {view === "viz" && (
-        <Box h="500px">
+        <Box>
           <InteractiveQuestion.FilterBar />
           <InteractiveQuestion.QuestionVisualization />
         </Box>

--- a/src/components/InteractiveQuestionView.tsx
+++ b/src/components/InteractiveQuestionView.tsx
@@ -77,7 +77,7 @@ export const InteractiveQuestionView = ({ isSaveEnabled = false }: Props) => {
       </Flex>
 
       {view === "viz" && (
-        <Box h={500}>
+        <Box h="500px">
           <InteractiveQuestion.FilterBar />
           <InteractiveQuestion.QuestionVisualization />
         </Box>

--- a/src/components/InteractiveQuestionView.tsx
+++ b/src/components/InteractiveQuestionView.tsx
@@ -77,7 +77,7 @@ export const InteractiveQuestionView = ({ isSaveEnabled = false }: Props) => {
       </Flex>
 
       {view === "viz" && (
-        <Box>
+        <Box h={500}>
           <InteractiveQuestion.FilterBar />
           <InteractiveQuestion.QuestionVisualization />
         </Box>

--- a/src/routes/product-detail/ProductDetailInsights.tsx
+++ b/src/routes/product-detail/ProductDetailInsights.tsx
@@ -1,4 +1,4 @@
-import { Card, Title, Box, Modal } from "@mantine/core"
+import { Card, Title, Box, Modal, Flex } from "@mantine/core"
 import { useDisclosure } from "@mantine/hooks"
 
 import {
@@ -57,18 +57,19 @@ export const ProductDetailInsights = (props: Props) => {
         withCloseButton={false}
         size="xl"
       >
-        <InteractiveQuestion
-          questionId={158}
-          height={700}
-          withTitle
-          customTitle={
-            <Title fw={400} size="h2" className="product-detail-card-title">
-              Orders over time
-            </Title>
-          }
-        >
-          <InteractiveQuestionView />
-        </InteractiveQuestion>
+        <Flex mih={700}>
+          <InteractiveQuestion
+            questionId={158}
+            withTitle
+            customTitle={
+              <Title fw={400} size="h2" className="product-detail-card-title">
+                Orders over time
+              </Title>
+            }
+          >
+            <InteractiveQuestionView />
+          </InteractiveQuestion>
+        </Flex>
       </Modal>
     </Box>
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -1108,10 +1108,10 @@
   resolved "https://registry.yarnpkg.com/@mantine/utils/-/utils-6.0.21.tgz#6185506e91cba3e308aaa8ea9ababc8e767995d6"
   integrity sha512-33RVDRop5jiWFao3HKd3Yp7A9mEq4HAJxJPTuYm1NkdqX6aTKOQK7wT8v8itVodBp+sb4cJK6ZVdD1UurK/txQ==
 
-"@metabase/embedding-sdk-react@^0.51.9":
-  version "0.51.9"
-  resolved "https://registry.yarnpkg.com/@metabase/embedding-sdk-react/-/embedding-sdk-react-0.51.9.tgz#87007a1a6cbce76dff5c17bc1bf628e55a15d7d7"
-  integrity sha512-FP6Jf1EwMbrDpZuItgNg13FIkt2bK/FZHmwX3By2q6j2YYqc5bYx40a+6Vk5gPX+HtW88Hxgx/7rb9ZoMCIC3w==
+"@metabase/embedding-sdk-react@^0.51.10":
+  version "0.51.10"
+  resolved "https://registry.yarnpkg.com/@metabase/embedding-sdk-react/-/embedding-sdk-react-0.51.10.tgz#ef1ade948c5feb96d59e3fab7314656500412119"
+  integrity sha512-KwfI7Fh6X5LFEXVHZaboXrJcnDoCKUBeXfYl+CYWLkAOUyxw/ImiwtwjqpnrQ29Nlr3Y7Wgnw6fG2Km0lf4BUQ==
   dependencies:
     "@dnd-kit/core" "^6.0.8"
     "@dnd-kit/modifiers" "^6.0.1"


### PR DESCRIPTION
Fixes the Shoppy modal from being cut-off when clicking on the chart in the product page, and bumps the sdk version. This appears to be a modal-specific issue.

![CleanShot 2567-11-30 at 02 31 35@2x](https://github.com/user-attachments/assets/f2a3d160-37a7-45af-b4dc-8b4ce8c6715e)
