### PR TITLE
ProficiencyLabs follow-up theme updates

### DIFF
--- a/src/components/ProficiencyGradient.tsx
+++ b/src/components/ProficiencyGradient.tsx
@@ -6,8 +6,6 @@ export const ProficiencyGradient = () => {
   return (
     <Box className="proficiency-gradient show-only-on-proficiency">
       <svg
-        // width="1103"
-        // height="345"
         viewBox="0 0 1103 345"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"

--- a/src/components/ProficiencyGradient.tsx
+++ b/src/components/ProficiencyGradient.tsx
@@ -6,6 +6,8 @@ export const ProficiencyGradient = () => {
   return (
     <Box className="proficiency-gradient show-only-on-proficiency">
       <svg
+        // width="1103"
+        // height="345"
         viewBox="0 0 1103 345"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"

--- a/src/components/ProficiencyGradient.tsx
+++ b/src/components/ProficiencyGradient.tsx
@@ -1,0 +1,161 @@
+import React from "react"
+
+import { Box } from "@mantine/core"
+
+export const ProficiencyGradient = () => {
+  return (
+    <Box className="proficiency-gradient show-only-on-proficiency">
+      <svg
+        viewBox="0 0 1103 345"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g filter="url(#filter0_f_2656_5250)">
+          <path
+            d="M1061.3 -107.575C1094.73 -82.4346 1113.91 -118.843 1146.05 -110.854C1260.25 -82.4746 1157.92 177.466 1031.76 167.945C912.402 158.936 898.161 -97.4186 898.161 -97.4186C898.161 -97.4186 902.016 -161.981 932.459 -175.387C959.933 -187.485 983.705 -175.857 1007.11 -157.062C1025.61 -142.212 1042.34 -121.829 1061.3 -107.575Z"
+            fill="#B4DEFC"
+          />
+        </g>
+        <g filter="url(#filter1_f_2656_5250)">
+          <path
+            d="M824.5 -163.315C862.871 -134.455 884.888 -176.263 921.784 -167.097C1052.85 -134.534 935.344 163.947 790.539 153.04C653.541 142.72 637.244 -151.621 637.244 -151.621C637.244 -151.621 641.683 -225.751 676.629 -241.15C708.166 -255.047 735.45 -241.7 762.315 -220.124C783.539 -203.078 802.745 -179.677 824.5 -163.315Z"
+            fill="#B0AAF7"
+          />
+        </g>
+        <g filter="url(#filter2_f_2656_5250)">
+          <ellipse
+            cx="590.893"
+            cy="-69.1782"
+            rx="157.82"
+            ry="157.643"
+            transform="rotate(23.7449 590.893 -69.1782)"
+            fill="#B854D3"
+          />
+        </g>
+        <g filter="url(#filter3_f_2656_5250)">
+          <path
+            d="M374.684 -204.558C337.207 -163.281 313.9 -129.515 317.192 -73.8659C323.61 34.6302 486.388 105.403 571.733 38.1075C639.187 -15.0816 609.845 -94.5883 600.599 -179.989C596.52 -217.672 603.054 -244.703 580.112 -274.848C528.772 -342.305 431.707 -267.362 374.684 -204.558Z"
+            fill="#FDD394"
+          />
+        </g>
+        <g filter="url(#filter4_f_2656_5250)">
+          <ellipse
+            cx="302.81"
+            cy="-14.1417"
+            rx="125.832"
+            ry="125.655"
+            transform="rotate(23.7449 302.81 -14.1417)"
+            fill="#FBE7B0"
+          />
+        </g>
+        <defs>
+          <filter
+            id="filter0_f_2656_5250"
+            x="721.43"
+            y="-357.062"
+            width="650.883"
+            height="701.992"
+            filterUnits="userSpaceOnUse"
+            colorInterpolationFilters="sRGB"
+          >
+            <feFlood floodOpacity="0" result="BackgroundImageFix" />
+            <feBlend
+              mode="normal"
+              in="SourceGraphic"
+              in2="BackgroundImageFix"
+              result="shape"
+            />
+            <feGaussianBlur
+              stdDeviation="88.3652"
+              result="effect1_foregroundBlur_2656_5250"
+            />
+          </filter>
+          <filter
+            id="filter1_f_2656_5250"
+            x="460.516"
+            y="-423.564"
+            width="694.836"
+            height="753.627"
+            filterUnits="userSpaceOnUse"
+            colorInterpolationFilters="sRGB"
+          >
+            <feFlood floodOpacity="0" result="BackgroundImageFix" />
+            <feBlend
+              mode="normal"
+              in="SourceGraphic"
+              in2="BackgroundImageFix"
+              result="shape"
+            />
+            <feGaussianBlur
+              stdDeviation="88.3652"
+              result="effect1_foregroundBlur_2656_5250"
+            />
+          </filter>
+          <filter
+            id="filter2_f_2656_5250"
+            x="256.332"
+            y="-403.621"
+            width="669.121"
+            height="668.884"
+            filterUnits="userSpaceOnUse"
+            colorInterpolationFilters="sRGB"
+          >
+            <feFlood floodOpacity="0" result="BackgroundImageFix" />
+            <feBlend
+              mode="normal"
+              in="SourceGraphic"
+              in2="BackgroundImageFix"
+              result="shape"
+            />
+            <feGaussianBlur
+              stdDeviation="88.3652"
+              result="effect1_foregroundBlur_2656_5250"
+            />
+          </filter>
+          <filter
+            id="filter3_f_2656_5250"
+            x="140.152"
+            y="-478.142"
+            width="651.508"
+            height="719.269"
+            filterUnits="userSpaceOnUse"
+            colorInterpolationFilters="sRGB"
+          >
+            <feFlood floodOpacity="0" result="BackgroundImageFix" />
+            <feBlend
+              mode="normal"
+              in="SourceGraphic"
+              in2="BackgroundImageFix"
+              result="shape"
+            />
+            <feGaussianBlur
+              stdDeviation="88.3652"
+              result="effect1_foregroundBlur_2656_5250"
+            />
+          </filter>
+          <filter
+            id="filter4_f_2656_5250"
+            x="0.24234"
+            y="-316.588"
+            width="605.133"
+            height="604.892"
+            filterUnits="userSpaceOnUse"
+            colorInterpolationFilters="sRGB"
+          >
+            <feFlood floodOpacity="0" result="BackgroundImageFix" />
+            <feBlend
+              mode="normal"
+              in="SourceGraphic"
+              in2="BackgroundImageFix"
+              result="shape"
+            />
+            <feGaussianBlur
+              stdDeviation="88.3652"
+              result="effect1_foregroundBlur_2656_5250"
+            />
+          </filter>
+        </defs>
+      </svg>
+    </Box>
+  )
+}

--- a/src/components/layout/Shell.tsx
+++ b/src/components/layout/Shell.tsx
@@ -147,7 +147,7 @@ export function Shell(props: Props) {
           </Flex>
         </AppShell.Navbar>
 
-        <AppShell.Main pt="90px">
+        <AppShell.Main>
           <Box mih="78vh">{props.children}</Box>
 
           <SiteFooter />

--- a/src/components/layout/Shell.tsx
+++ b/src/components/layout/Shell.tsx
@@ -23,6 +23,7 @@ import { siteIsReloadingAtom } from "../../store/site"
 import { useAtom } from "jotai"
 import { FullPageLoader } from "../Loader"
 import { SiteFooter } from "../SiteFooter"
+import { ProficiencyGradient } from "../ProficiencyGradient"
 
 interface Props {
   children: ReactNode
@@ -148,6 +149,8 @@ export function Shell(props: Props) {
         </AppShell.Navbar>
 
         <AppShell.Main>
+          <ProficiencyGradient />
+
           <Box mih="78vh">{props.children}</Box>
 
           <SiteFooter />

--- a/src/components/layout/SidebarLinks.tsx
+++ b/src/components/layout/SidebarLinks.tsx
@@ -82,7 +82,7 @@ const renderLink = (
       }}
       classNames={{
         chevron: "sidebar-link-chevron",
-        children: "sidebar-link-children-container space-y-1",
+        children: "sidebar-link-children-container",
         collapse: "sidebar-link-collapse",
         body: cx(
           "flex-[2]",

--- a/src/components/layout/SidebarLinks.tsx
+++ b/src/components/layout/SidebarLinks.tsx
@@ -83,7 +83,6 @@ const renderLink = (
       classNames={{
         chevron: "sidebar-link-chevron",
         children: "sidebar-link-children-container",
-        collapse: "sidebar-link-collapse",
         body: cx(
           "flex-[2]",
 

--- a/src/components/layout/SidebarLinks.tsx
+++ b/src/components/layout/SidebarLinks.tsx
@@ -83,6 +83,7 @@ const renderLink = (
       classNames={{
         chevron: "sidebar-link-chevron",
         children: "sidebar-link-children-container space-y-1",
+        collapse: "sidebar-link-collapse",
         body: cx(
           "flex-[2]",
 

--- a/src/routes/analytics/AnalyticsCustomPage.tsx
+++ b/src/routes/analytics/AnalyticsCustomPage.tsx
@@ -25,7 +25,7 @@ export function AnalyticsCustomPage() {
   useReloadOnSiteChange()
 
   return (
-    <Container w="100%" p={20}>
+    <Container w="100%" p={20} pt="80px">
       <Flex justify="flex-end" gap="xs" pb="xs" className="hide-on-mobile">
         <NewQuestionMenu position="bottom-end">
           <ThemedButton>New Question</ThemedButton>

--- a/src/routes/analytics/AnalyticsOverviewPage.tsx
+++ b/src/routes/analytics/AnalyticsOverviewPage.tsx
@@ -6,7 +6,7 @@ import { overviewLinkCards } from "./link-cards"
 
 export function AnalyticsOverviewPage() {
   return (
-    <Container>
+    <Container pt="80px">
       <Title className="overview-title" pb="30px">
         Overview
       </Title>

--- a/src/routes/analytics/DashboardPage.tsx
+++ b/src/routes/analytics/DashboardPage.tsx
@@ -15,13 +15,13 @@ export function DashboardPage(props: Props) {
   useReloadOnSiteChange()
 
   return (
-    <Box mih="100vh" className="dashboard-container smartscalar">
+    <Box mih="100vh" className="dashboard-container smartscalar" pt="40px">
       <InteractiveDashboard
         dashboardId={dashboardId}
         withTitle
         withDownloads={false}
         renderDrillThroughQuestion={() => (
-          <Container size="1000px" w="100%">
+          <Container size="1000px" w="100%" pt="40px">
             <InteractiveQuestionView isSaveEnabled={false} />
           </Container>
         )}

--- a/src/routes/analytics/DashboardPage.tsx
+++ b/src/routes/analytics/DashboardPage.tsx
@@ -15,7 +15,7 @@ export function DashboardPage(props: Props) {
   useReloadOnSiteChange()
 
   return (
-    <Box mih="100vh" className="dashboard-container smartscalar" pt="40px">
+    <Box mih="100vh" className="dashboard-container smartscalar" pt="30px">
       <InteractiveDashboard
         dashboardId={dashboardId}
         withTitle

--- a/src/routes/analytics/QuestionPage.tsx
+++ b/src/routes/analytics/QuestionPage.tsx
@@ -12,7 +12,7 @@ export function QuestionPage(props: Props) {
   const questionId = parseInt(props.id, 10)
 
   return (
-    <Container mih="100vh" className="smartscalar" pt="80px">
+    <Container mih="100vh" className="question-container smartscalar" pt="80px">
       <RemountOnSiteChange>
         <InteractiveQuestion questionId={questionId}>
           <InteractiveQuestionView />

--- a/src/routes/analytics/QuestionPage.tsx
+++ b/src/routes/analytics/QuestionPage.tsx
@@ -12,7 +12,7 @@ export function QuestionPage(props: Props) {
   const questionId = parseInt(props.id, 10)
 
   return (
-    <Container mih="100vh" className="smartscalar">
+    <Container mih="100vh" className="smartscalar" pt="80px">
       <RemountOnSiteChange>
         <InteractiveQuestion questionId={questionId}>
           <InteractiveQuestionView />

--- a/src/routes/analytics/new/NewFromTemplatePage.tsx
+++ b/src/routes/analytics/new/NewFromTemplatePage.tsx
@@ -22,7 +22,7 @@ export const NewFromTemplatePage = () => {
 
   if (templateOrSavedQuestionId === undefined) {
     return (
-      <Container>
+      <Container pt="80px">
         <Title fz="28px" mb="md">
           Pick a question
         </Title>
@@ -38,7 +38,7 @@ export const NewFromTemplatePage = () => {
 
   if (templateOrSavedQuestionId !== undefined) {
     return (
-      <Container w="100%">
+      <Container w="100%" pt="80px">
         <InteractiveQuestion
           onSave={onSaveQuestion}
           saveToCollectionId={collectionId}

--- a/src/routes/product-detail/index.tsx
+++ b/src/routes/product-detail/index.tsx
@@ -42,7 +42,7 @@ export const ProductDetailPage = ({ id }: Props) => {
   if (!product) return <div>Product not found</div>
 
   return (
-    <Container>
+    <Container pt="80px">
       <Box>
         <Text className="product-detail-title" pb="5px">
           {truncate(product.title, 50)}

--- a/src/routes/product-list/ProductCard.tsx
+++ b/src/routes/product-list/ProductCard.tsx
@@ -41,7 +41,7 @@ export const ProductCard = ({ product }: Props) => {
               {truncate(product.title, truncateLength)}
             </Text>
 
-            <Box py={4} mih={questionHeight}>
+            <Box py={4} h={questionHeight}>
               <LoadWhenVisible>
                 <RemountOnSiteChange>
                   <StaticQuestion

--- a/src/routes/product-list/index.tsx
+++ b/src/routes/product-list/index.tsx
@@ -40,7 +40,8 @@ export const ProductAnalyticsPage = (props: Props) => {
   }
 
   const currentCategoryName =
-    categoryQuery.data?.find((category) => category.id === categoryId)?.name ?? "All products"
+    categoryQuery.data?.find((category) => category.id === categoryId)?.name ??
+    "All products"
 
   // If the site changes, redirect back to the product listing page.
   // This ensures we don't show product from last site's categories.
@@ -49,7 +50,7 @@ export const ProductAnalyticsPage = (props: Props) => {
   if (query.isLoading) return <FullPageLoader />
 
   return (
-    <Container>
+    <Container pt="80px">
       <Stack w="100%" maw="1000px" className="gap-y-10">
         <Title className="overview-title">{currentCategoryName}</Title>
 

--- a/src/styles/dashboard-workaround.css
+++ b/src/styles/dashboard-workaround.css
@@ -66,4 +66,10 @@ body[data-theme="proficiency"] .dashboard-container {
   footer {
     border: none;
   }
+
+  h2 {
+    color: var(--color-dark-grey);
+    font-size: 32px;
+    font-weight: 700;
+  }
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -66,7 +66,3 @@ body:not([data-theme="luminara"]) {
   @apply space-y-3;
 }
 
-/** removes the hidden collapse element as it adds unwanted spacing when space-y-1 is applied */
-.sidebar-link-children-container .sidebar-link-collapse {
-  display: none;
-}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -65,3 +65,8 @@ body:not([data-theme="luminara"]) {
 .sidebar-links-container {
   @apply space-y-3;
 }
+
+/** removes the hidden collapse element as it adds unwanted spacing when space-y-1 is applied */
+.sidebar-link-children-container .sidebar-link-collapse {
+  display: none;
+}

--- a/src/themes/proficiency.css
+++ b/src/themes/proficiency.css
@@ -179,6 +179,11 @@ body[data-theme="proficiency"] {
       font-weight: 700;
     }
   }
+
+  .sidebar-action-button {
+    width: 100%;
+    height: 36px;
+  }
 }
 
 body:not([data-theme="proficiency"]) .show-only-on-proficiency {

--- a/src/themes/proficiency.css
+++ b/src/themes/proficiency.css
@@ -186,18 +186,19 @@ body[data-theme="proficiency"] {
   }
 
   .proficiency-gradient {
-    @apply fixed top-10 right-0 z-[-10] pointer-events-none;
+    position: fixed;
+    top: 40px;
+    right: 0px;
+    z-index: -1;
+    pointer-events: none;
+    width: 70%;
 
-    svg {
-      width: 850px;
-      height: 265px;
+    @media screen and (max-width: 768px) {
+      width: 80%;
     }
 
-    @media screen and (max-width: 640px) {
-      svg {
-        width: 367px;
-        height: 115px;
-      }
+    @media screen and (max-width: 600px) {
+      width: 100%;
     }
   }
 }

--- a/src/themes/proficiency.css
+++ b/src/themes/proficiency.css
@@ -186,7 +186,7 @@ body[data-theme="proficiency"] {
   }
 
   .proficiency-gradient {
-    position: fixed;
+    position: absolute;
     top: 40px;
     right: 0px;
     z-index: -1;
@@ -199,6 +199,13 @@ body[data-theme="proficiency"] {
 
     @media screen and (max-width: 600px) {
       width: 100%;
+    }
+  }
+
+  .question-container, .dashboard-container {
+    /* WORKAROUND: hide the table background, while keeping popover backgrounds white */
+    [role="gridcell"], [role="columnheader"], [data-testid="TableInteractive-root"], [aria-label="grid"] {
+      background: transparent;
     }
   }
 }

--- a/src/themes/proficiency.css
+++ b/src/themes/proficiency.css
@@ -122,7 +122,7 @@ body[data-theme="proficiency"] {
   }
 
   .sidebar-link-title {
-    color: var(--color-light-grey);
+    color: var(--color-dark-grey);
   }
 
   .sidebar-icons svg {

--- a/src/themes/proficiency.css
+++ b/src/themes/proficiency.css
@@ -57,6 +57,10 @@ body[data-theme="proficiency"] {
     padding-inline-start: 0px;
   }
 
+  .sidebar-child-container .sidebar-link-title {
+    color: var(--color-light-grey);
+  }
+  
   .sidebar-active-child {
     background: rgba(106, 87, 201, 0.1);
     transition: background 0.4s ease;
@@ -119,10 +123,6 @@ body[data-theme="proficiency"] {
 
   .sidebar-links-container {
     @apply space-y-1;
-  }
-
-  .sidebar-link-title {
-    color: var(--color-dark-grey);
   }
 
   .sidebar-icons svg {

--- a/src/themes/proficiency.css
+++ b/src/themes/proficiency.css
@@ -184,6 +184,22 @@ body[data-theme="proficiency"] {
     width: 100%;
     height: 36px;
   }
+
+  .proficiency-gradient {
+    @apply fixed top-10 right-0 z-[-10] pointer-events-none;
+
+    svg {
+      width: 850px;
+      height: 265px;
+    }
+
+    @media screen and (max-width: 640px) {
+      svg {
+        width: 367px;
+        height: 115px;
+      }
+    }
+  }
 }
 
 body:not([data-theme="proficiency"]) .show-only-on-proficiency {

--- a/src/themes/proficiency.ts
+++ b/src/themes/proficiency.ts
@@ -73,6 +73,7 @@ const metabase: MetabaseTheme = {
       padding: "6px 16px",
     },
     dashboard: {
+      backgroundColor: "transparent",
       card: {
         backgroundColor: "#FFFFFF",
         border: "1px solid rgba(0, 0, 0, 0.12)",


### PR DESCRIPTION
Closes https://github.com/metabase/shoppy/issues/92

Minor theming updates to match the [Figma](https://www.figma.com/design/OamRqg07JOoC4bUqfCkh4t/SDK-Reference-APP?node-id=2656-4806&t=DgugKlCspSqJ69na-1) design more closely.

## Changes

- In the "Inventory performance" page, the title is now larger like in the other screens. The content is no longer pushed too far down.
- Make the two primary buttons in the sidebar have the same width, and make them taller.
- Add the colorful gradient from the design.
- Prevents the "See more" button jumping after the static question has loaded on the product list page
- Match the sidebar nav item spacing with the design. The Figma design does not have a lot of vertical spacing.

## Demo

![CleanShot 2568-01-14 at 21 48 14@2x](https://github.com/user-attachments/assets/9c3a8361-b24f-4134-bbc5-81ac764d31e0)


