### PR TITLE
Bump SDK, fix theme color and apply modular question

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
 
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#151C20" />
+    <meta name="theme-color" content="#FCFDFD" />
     <meta name="description" content="Shoppy" />
 
     <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@mantine/core": "^7.8.0",
     "@mantine/form": "^7.8.0",
     "@mantine/hooks": "^7.8.0",
-    "@metabase/embedding-sdk-react": "^0.52.6",
+    "@metabase/embedding-sdk-react": "^0.52.7",
     "@tanstack/react-query": "^5.32.0",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",

--- a/src/components/InteractiveQuestionView.tsx
+++ b/src/components/InteractiveQuestionView.tsx
@@ -1,6 +1,6 @@
 import { useReducer } from "react"
 import { useAtom } from "jotai"
-import { Box, Flex, Group, Modal } from "@mantine/core"
+import { Box, Flex, Group, Modal, Popover } from "@mantine/core"
 import { InteractiveQuestion } from "@metabase/embedding-sdk-react"
 
 import { CustomIcon } from "./CustomIcon"
@@ -45,21 +45,33 @@ export const InteractiveQuestionView = ({ isSaveEnabled = false }: Props) => {
         </Group>
 
         <Group gap="xs">
-          <ThemedButton
-            size="compact-sm"
-            leftSection={<CustomIcon icon="filter" />}
-            onClick={() => changeView("filter")}
-          >
-            Add a filter
-          </ThemedButton>
+          <Popover position="bottom-end">
+            <Popover.Target>
+              <ThemedButton
+                size="compact-sm"
+                leftSection={<CustomIcon icon="filter" />}
+              >
+                Change the filter
+              </ThemedButton>
+            </Popover.Target>
+            <Popover.Dropdown>
+              <InteractiveQuestion.Filter withColumnItemIcon />
+            </Popover.Dropdown>
+          </Popover>
 
-          <ThemedButton
-            size="compact-sm"
-            leftSection={<CustomIcon icon="sum" />}
-            onClick={() => changeView("summary")}
-          >
-            Change the summary
-          </ThemedButton>
+          <Popover position="bottom-end">
+            <Popover.Target>
+              <ThemedButton
+                size="compact-sm"
+                leftSection={<CustomIcon icon="sum" />}
+              >
+                Change the summary
+              </ThemedButton>
+            </Popover.Target>
+            <Popover.Dropdown>
+              <InteractiveQuestion.Summarize />
+            </Popover.Dropdown>
+          </Popover>
 
           {isSaveEnabled && (
             <ThemedButton
@@ -78,17 +90,8 @@ export const InteractiveQuestionView = ({ isSaveEnabled = false }: Props) => {
 
       {view === "viz" && (
         <Box h="500px">
-          <InteractiveQuestion.FilterBar />
           <InteractiveQuestion.QuestionVisualization />
         </Box>
-      )}
-
-      {view === "filter" && (
-        <InteractiveQuestion.Filter onClose={() => changeView("viz")} />
-      )}
-
-      {view === "summary" && (
-        <InteractiveQuestion.Summarize onClose={() => changeView("viz")} />
       )}
 
       {view === "editor" && (

--- a/src/routes/analytics/DashboardPage.tsx
+++ b/src/routes/analytics/DashboardPage.tsx
@@ -21,7 +21,12 @@ export function DashboardPage(props: Props) {
         withTitle
         withDownloads={false}
         renderDrillThroughQuestion={() => (
-          <Container size="1000px" w="100%" pt="40px">
+          <Container
+            size="1000px"
+            w="100%"
+            pt="40px"
+            className="drill-question-container"
+          >
             <InteractiveQuestionView isSaveEnabled={false} />
           </Container>
         )}

--- a/src/themes/luminara.ts
+++ b/src/themes/luminara.ts
@@ -43,7 +43,7 @@ const metabase: MetabaseTheme = {
     background: colors.background,
     "background-secondary": colors.background,
     "background-hover": colors.background,
-    "background-disabled": colors.green2,
+    "background-disabled": "#d6d6d6",
     charts: [
       colors.viz1,
       "#E09862",

--- a/src/themes/proficiency.css
+++ b/src/themes/proficiency.css
@@ -208,6 +208,13 @@ body[data-theme="proficiency"] {
       background: transparent;
     }
   }
+
+  .drill-question-container h2 {
+    width: 400px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 }
 
 body:not([data-theme="proficiency"]) .show-only-on-proficiency {

--- a/src/themes/proficiency.ts
+++ b/src/themes/proficiency.ts
@@ -37,7 +37,7 @@ const metabase: MetabaseTheme = {
     filter: colors.primary,
     "text-primary": colors.lightGrey,
     "text-secondary": colors.lightGrey,
-    "text-tertiary": "rgba(0, 0, 0, 0.5)",
+    "text-tertiary": "rgba(0, 0, 0, 0.4)",
     border: "rgba(0, 0, 0, 0.12)",
     background: colors.background,
     "background-hover": "#fCFDFD",

--- a/src/themes/proficiency.ts
+++ b/src/themes/proficiency.ts
@@ -37,11 +37,11 @@ const metabase: MetabaseTheme = {
     filter: colors.primary,
     "text-primary": colors.lightGrey,
     "text-secondary": colors.lightGrey,
-    "text-tertiary": colors.lightGrey,
+    "text-tertiary": "rgba(0, 0, 0, 0.5)",
     border: "rgba(0, 0, 0, 0.12)",
     background: colors.background,
     "background-hover": "#fCFDFD",
-    "background-disabled": colors.lighterGrey,
+    "background-disabled": "rgba(0, 0, 0, 0.1)",
     charts: [
       colors.primary,
       "rgba(37, 90, 157, 1)",

--- a/src/themes/pug.ts
+++ b/src/themes/pug.ts
@@ -57,6 +57,19 @@ const metabase: MetabaseTheme = {
     negative: colors.negative,
   },
   components: {
+    tooltip: {
+      /** Tooltip text color. */
+      textColor: colors.darkGrey,
+
+      /** Secondary text color shown in the tooltip, e.g. for tooltip headers and percentage changes. */
+      secondaryTextColor: colors.darkGrey,
+
+      /** Tooltip background color. */
+      backgroundColor: colors.background,
+
+      /** Tooltip background color for focused rows. */
+      focusedBackgroundColor: colors.lighterGrey,
+    },
     cartesian: {
       padding: "6px 16px",
     },

--- a/src/themes/stitch.ts
+++ b/src/themes/stitch.ts
@@ -9,7 +9,7 @@ const colors = {
   lighterGrey: "#E3E7E4",
   lightGrey: "#ADABA9",
   darkGrey: "#3B3F3F",
-  background: "#151C20",
+  background: "#161A1D",
 }
 
 const mantine: MantineThemeOverride = {

--- a/src/themes/variables.css
+++ b/src/themes/variables.css
@@ -4,7 +4,7 @@ body[data-theme="stitch"] {
   --color-lighter-grey: #e3e7e4;
   --color-light-grey: #c4c9c7;
   --color-dark-grey: #3b3f3f;
-  --color-background: #151c20;
+  --color-background: #161a1d;
   --color-footer-icon: var(--color-light-grey);
   --icon-primary: var(--color-primary);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1108,10 +1108,10 @@
   resolved "https://registry.yarnpkg.com/@mantine/utils/-/utils-6.0.21.tgz#6185506e91cba3e308aaa8ea9ababc8e767995d6"
   integrity sha512-33RVDRop5jiWFao3HKd3Yp7A9mEq4HAJxJPTuYm1NkdqX6aTKOQK7wT8v8itVodBp+sb4cJK6ZVdD1UurK/txQ==
 
-"@metabase/embedding-sdk-react@^0.52.6":
-  version "0.52.6"
-  resolved "https://registry.yarnpkg.com/@metabase/embedding-sdk-react/-/embedding-sdk-react-0.52.6.tgz#6fbf6ce0674306f1ac4643fe464a6c10ab627e3a"
-  integrity sha512-wRtfaB4tDqP55WDz6seH7PCeC1vOxZw7q6elerYKphSv9VRlZlB1f3ae/IHqfvT8XOuFGf9GOUoD7z/85grsiA==
+"@metabase/embedding-sdk-react@^0.52.7":
+  version "0.52.7"
+  resolved "https://registry.yarnpkg.com/@metabase/embedding-sdk-react/-/embedding-sdk-react-0.52.7.tgz#260895eeb95d7e42797b4097b261349cc523998b"
+  integrity sha512-OyZVk/6SBlN9/kivlWFTgDm0LrM61xMoJsm9ELerT/GoGKtxCMhE7qaWJjDPyDrKUucAMgTRoVhghsHqpbidnw==
   dependencies:
     "@dnd-kit/core" "^6.0.8"
     "@dnd-kit/modifiers" "^6.0.1"


### PR DESCRIPTION
Closes https://github.com/metabase/shoppy/issues/96

Turns out I was using the wrong `text-tertiary` and `background-disabled` colors, and that partly caused the issue with https://github.com/metabase/metabase/issues/52027. This PR updates both to be visually correct.

![CleanShot 2568-01-22 at 18 25 35@2x](https://github.com/user-attachments/assets/9a45d164-a526-4fca-86ac-63d9570a2054)

That needed a version bump because of https://github.com/metabase/metabase/pull/52075. It also applies the modular querying components in https://github.com/metabase/shoppy/pull/95/commits/28ddabbfdef6b3458d3581d495537e0e42ebe8c3 - this is needed because `Filter`, `FilterBar` and `Summarize` are all gone. Without this the QuestionView crashes because of missing components. We will switch to the default view in the next PR, but that is blocking on https://github.com/metabase/metabase/issues/52261 in the SDK.

![CleanShot 2568-01-22 at 18 30 40@2x](https://github.com/user-attachments/assets/6bc8c7e2-32e6-4e22-a416-8c9269cab6ad)

Finally, it also updates a bunch more incorrect theme color values in other themes, and adds tooltip theme colors to pug.
