### PR TITLE
Change tailwind config export type

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,5 @@
 /** @type {import('tailwindcss').Config} */
-module.exports = {
+export default {
   content: ["./src/**/*.{js,jsx,ts,tsx}"],
   theme: {
     extend: {


### PR DESCRIPTION
On node@22 i got the following error
```
ReferenceError: module is not defined
```

The PR changes export in the tailwind config to avoid this issue.
This change also allows to remove a hack (that removes this module type) when this app is used in e2e testing

How to verify?
- run `yarn dev` using node@18, node@20 and node@22
- you should not see any errors
- the app should work