### PR TITLE
Remove session.ts as it is unused

### DIFF
--- a/api/src/types/session.ts
+++ b/api/src/types/session.ts
@@ -1,7 +1,0 @@
-import { User } from "./user"
-
-declare module "express-session" {
-  export interface SessionData {
-    user: User
-  }
-}


### PR DESCRIPTION
Remove session.ts as it is unused
Also, when building an app, it causes the `Invalid module name in augmentation, and module 'express-session' cannot be found.` error

How to verify:
- local `cd api`, then `yarn build`. Build should be successful