### PR TITLE
Fix footer issue

### DIFF
--- a/src/components/layout/Shell.tsx
+++ b/src/components/layout/Shell.tsx
@@ -159,9 +159,9 @@ export function Shell(props: Props) {
 
         <Stack h="100%" py="xl">
           <Box className="flex-1">{props.children}</Box>
-        </Stack>
 
-        <SiteFooter />
+          <SiteFooter />
+        </Stack>
 
         <ClickActionDemoModal />
       </AppShell.Main>


### PR DESCRIPTION
<img width="1382" alt="image" src="https://github.com/user-attachments/assets/ad5b4b1d-1997-4e18-9222-6a958004a2e6" />
<img width="1301" alt="image" src="https://github.com/user-attachments/assets/01653810-5e61-4b19-8844-03177c2adc1e" />

There's one issue with the `Inventory performance` section - the footer is outside the viewport. However, this is because the dashboard is taking up way more space than it needs and is a bug in itself. I'll take a look at that later 