### PR TITLE
theStitch should use different colors for placeholder text

### DIFF
--- a/src/themes/stitch.ts
+++ b/src/themes/stitch.ts
@@ -38,7 +38,7 @@ const metabase: MetabaseTheme = {
     filter: colors.filter,
     "text-primary": colors.lighterGrey,
     "text-secondary": colors.lighterGrey,
-    "text-tertiary": colors.lighterGrey,
+    "text-tertiary": colors.lightGrey,
     border: colors.darkGrey,
     background: colors.background,
     "background-secondary": colors.darkGrey,


### PR DESCRIPTION
Closes [EMB-274](https://linear.app/metabase/issue/EMB-274/[shoppy]-thestitch-should-use-a-different-text-placeholder-color-than)

Use grey text for placeholder colors in theStitch.

![CleanShot 2568-03-18 at 22 25 52@2x](https://github.com/user-attachments/assets/a7cfe4a8-6877-449d-9bed-df2956821fe6)
