### PR TITLE
Revert #110 to fix flickering issues on main

### DIFF
--- a/src/constants/collections.ts
+++ b/src/constants/collections.ts
@@ -1,17 +1,17 @@
 import { SiteKey } from "../types/site"
 
-export const QUESTION_TEMPLATE_COLLECTION_ID = "wMtVlfN46XKdxw-AE6iEA"
+export const QUESTION_TEMPLATE_COLLECTION_ID = 42
 
-export const SANDBOXED_CUSTOM_ANALYTICS_COLLECTIONS: Record<SiteKey, string> = {
-  stitch: "AsgXAPPxfjHkV_bXv1MhA",
-  luminara: "g0FmUQnNqLT6xnJL2bWMF",
-  pug: "3vHp_t-NNNJD9YAs6Vt1j",
-  proficiency: "RJ9Hcd1mqaFKQvZzABB3t",
+export const SANDBOXED_CUSTOM_ANALYTICS_COLLECTIONS: Record<SiteKey, number> = {
+  stitch: 45,
+  luminara: 46,
+  pug: 47,
+  proficiency: 100,
 }
 
-export const SANDBOXED_USER_GENERATED_COLLECTIONS: Record<SiteKey, string> = {
-  stitch: "HPAvJNTD9XTRkwJZUX9Fz",
-  luminara: "FswOnCotqpwb96gqOkYU1",
-  pug: "Il4ywja-XJRgB8VbCzOTb",
-  proficiency: "H8kX2zn3T6KLE44DdgKQ8",
+export const SANDBOXED_USER_GENERATED_COLLECTIONS: Record<SiteKey, number> = {
+  stitch: 48,
+  luminara: 49,
+  pug: 50,
+  proficiency: 101,
 }

--- a/src/routes/analytics/AnalyticsCustomPage.tsx
+++ b/src/routes/analytics/AnalyticsCustomPage.tsx
@@ -44,9 +44,9 @@ export function AnalyticsCustomPage() {
         className="analytics-collection-browser"
         onClick={(item) => {
           if (item.model === "dashboard") {
-            navigate(`/analytics/${item.entity_id}`)
+            navigate(`/analytics/${item.id}`)
           } else if (item.model === "card") {
-            navigate(`/question/${item.entity_id}`)
+            navigate(`/question/${item.id}`)
           }
         }}
       />

--- a/src/routes/analytics/AnalyticsOverviewPage.tsx
+++ b/src/routes/analytics/AnalyticsOverviewPage.tsx
@@ -14,7 +14,7 @@ export function AnalyticsOverviewPage() {
       <Stack>
         <SimpleGrid cols={{ base: 1, xs: 2, sm: 3, lg: 4 }}>
           {overviewLinkCards.map((card) => (
-            <DashboardLinkCard key={card.entityId} {...card} />
+            <DashboardLinkCard key={card.id} {...card} />
           ))}
         </SimpleGrid>
       </Stack>

--- a/src/routes/analytics/DashboardLinkCard.tsx
+++ b/src/routes/analytics/DashboardLinkCard.tsx
@@ -2,7 +2,7 @@ import { Link } from "wouter"
 import { Text, Card, Box, Title, Flex } from "@mantine/core"
 
 export interface DashboardLinkCardProps {
-  entityId: string
+  id: number
   title: string
   description?: string
   author: string
@@ -11,7 +11,7 @@ export interface DashboardLinkCardProps {
 
 export const DashboardLinkCard = (props: DashboardLinkCardProps) => {
   return (
-    <Link to={`/analytics/${props.entityId}`}>
+    <Link to={`/analytics/${props.id}`}>
       <Card className="card gap-y-5 justify-between" h="100%" withBorder p={12}>
         <Box>
           <Title size="h4">{props.title}</Title>

--- a/src/routes/analytics/DashboardPage.tsx
+++ b/src/routes/analytics/DashboardPage.tsx
@@ -5,17 +5,19 @@ import { useReloadOnSiteChange } from "../../utils/use-site-changed"
 import { withProductClickAction } from "../../utils/metabase-plugins"
 
 interface Props {
-  entity_id: string
+  id: string
 }
 
 export function DashboardPage(props: Props) {
+  const dashboardId = parseInt(props.id, 10)
+
   // When the site changed, reload to apply the site's sandboxed data.
   useReloadOnSiteChange()
 
   return (
     <Box mih="100vh" className="dashboard-container smartscalar">
       <InteractiveDashboard
-        dashboardId={props.entity_id}
+        dashboardId={dashboardId}
         withTitle
         withDownloads={false}
         plugins={{ mapQuestionClickActions: withProductClickAction() }}

--- a/src/routes/analytics/QuestionPage.tsx
+++ b/src/routes/analytics/QuestionPage.tsx
@@ -5,15 +5,17 @@ import { RemountOnSiteChange } from "../../components/RemountOnSiteChange"
 import { withProductClickAction } from "../../utils/metabase-plugins"
 
 interface Props {
-  entity_id: string
+  id: string
 }
 
 export function QuestionPage(props: Props) {
+  const questionId = parseInt(props.id, 10)
+
   return (
     <Container mih="100vh" className="question-container smartscalar">
       <RemountOnSiteChange>
         <InteractiveQuestion
-          questionId={props.entity_id}
+          questionId={questionId}
           plugins={{ mapQuestionClickActions: withProductClickAction() }}
         />
       </RemountOnSiteChange>

--- a/src/routes/analytics/link-cards.ts
+++ b/src/routes/analytics/link-cards.ts
@@ -2,7 +2,7 @@ import { DashboardLinkCardProps } from "./DashboardLinkCard"
 
 export const overviewLinkCards: DashboardLinkCardProps[] = [
   {
-    entityId: "i5s-lcGYLc1GyFdIy4TxH",
+    id: 17,
     title: "Inventory Performance",
     description:
       "Internal analytics dashboard visualizing key performance and inventory metrics for a demo training platform.",
@@ -10,7 +10,7 @@ export const overviewLinkCards: DashboardLinkCardProps[] = [
     date: "3mo",
   },
   {
-    entityId: "skc-qdKHq3FbwFLw0sE4c",
+    id: 12,
     title: "Orders",
     description:
       "An overview of the orders made by customers. The data is delayed by 2-3 day.",
@@ -18,7 +18,7 @@ export const overviewLinkCards: DashboardLinkCardProps[] = [
     date: "3mo",
   },
   {
-    entityId: "jcwoxpN2xgLk3agdlbC63",
+    id: 8,
     title: "Products",
     description:
       "An overview of the products sold by the shop. The data is delayed by 2-3 day.",

--- a/src/routes/analytics/new/NewDashboardPage.tsx
+++ b/src/routes/analytics/new/NewDashboardPage.tsx
@@ -23,9 +23,7 @@ export const NewDashboardPage = () => {
     return (
       <RemountOnSiteChange>
         <CreateDashboardModal
-          onCreate={(dashboard: { entity_id: string }) =>
-            setDashboardId(dashboard.entity_id)
-          }
+          onCreate={(dashboard: { id: number }) => setDashboardId(dashboard.id)}
           initialCollectionId={collectionId}
           onClose={() => navigate("/admin/analytics/custom")}
         />

--- a/src/routes/analytics/new/NewFromScratchPage.tsx
+++ b/src/routes/analytics/new/NewFromScratchPage.tsx
@@ -11,7 +11,7 @@ export const NewFromScratchPage = () => {
       <InteractiveQuestion
         questionId="new"
         onSave={onSaveQuestion}
-        targetCollection={collectionId}
+        saveToCollection={collectionId}
         isSaveEnabled
       />
     </Container>

--- a/src/routes/analytics/new/NewFromTemplatePage.tsx
+++ b/src/routes/analytics/new/NewFromTemplatePage.tsx
@@ -29,7 +29,7 @@ export const NewFromTemplatePage = () => {
         <CollectionBrowser
           collectionId={QUESTION_TEMPLATE_COLLECTION_ID}
           visibleEntityTypes={["question"]}
-          onClick={(item) => setQuestionId(item.entity_id)}
+          onClick={(item) => setQuestionId(item.id)}
         />
       </Container>
     )
@@ -40,7 +40,7 @@ export const NewFromTemplatePage = () => {
       <Container w="100%">
         <InteractiveQuestion
           onSave={onSaveQuestion}
-          targetCollection={collectionId}
+          saveToCollection={collectionId}
           questionId={templateOrSavedQuestionId}
           isSaveEnabled
         />

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -48,9 +48,7 @@ export const Routes = () => (
 
             <Route
               path="/analytics/:id"
-              component={(props) => (
-                <DashboardPage entity_id={props.params.id} />
-              )}
+              component={(props) => <DashboardPage id={props.params.id} />}
             />
 
             <Route
@@ -71,7 +69,7 @@ export const Routes = () => (
 
           <Route
             path="/question/:id"
-            component={(props) => <QuestionPage entity_id={props.params.id} />}
+            component={(props) => <QuestionPage id={props.params.id} />}
           />
         </Route>
 

--- a/src/routes/internal/KitchenSink.tsx
+++ b/src/routes/internal/KitchenSink.tsx
@@ -3,10 +3,15 @@ import { StaticQuestion } from "@metabase/embedding-sdk-react"
 
 import "./kitchen-sink.css"
 
-const questions: string[] = [
-  "MvyBus_qDW4SC8NshJ6zD",
-  "bYxRH9Yc8qCzh9PK-F-bV",
-  "wvMvO_S0FJlj010YbKOmT",
+const questions: number[] = [
+  // bar
+  95,
+
+  // line
+  96,
+
+  // area
+  97,
 ]
 
 export const KitchenSink = () => (
@@ -33,10 +38,7 @@ export const KitchenSink = () => (
       </Title>
 
       <Flex>
-        <StaticQuestion
-          questionId="MvyBus_qDW4SC8NshJ6zD"
-          withChartTypeSelector={false}
-        />
+        <StaticQuestion questionId={95} withChartTypeSelector={false} />
       </Flex>
 
       <Title pb={8} size="h4">
@@ -44,10 +46,7 @@ export const KitchenSink = () => (
       </Title>
 
       <Card w="100%">
-        <StaticQuestion
-          questionId="MvyBus_qDW4SC8NshJ6zD"
-          withChartTypeSelector={false}
-        />
+        <StaticQuestion questionId={95} withChartTypeSelector={false} />
       </Card>
 
       <Title pb={8} size="h4">
@@ -55,10 +54,7 @@ export const KitchenSink = () => (
       </Title>
 
       <Box w="100%">
-        <StaticQuestion
-          questionId="MvyBus_qDW4SC8NshJ6zD"
-          withChartTypeSelector={false}
-        />
+        <StaticQuestion questionId={95} withChartTypeSelector={false} />
       </Box>
 
       <Title pb={8} size="h4">
@@ -66,10 +62,7 @@ export const KitchenSink = () => (
       </Title>
 
       <Box w="100%" bg="white">
-        <StaticQuestion
-          questionId="t07HOjt9YiRHcWnK7XrgE"
-          withChartTypeSelector={false}
-        />
+        <StaticQuestion questionId={76} withChartTypeSelector={false} />
       </Box>
     </Stack>
   </Stack>

--- a/src/routes/product-detail/ProductDetailInsights.tsx
+++ b/src/routes/product-detail/ProductDetailInsights.tsx
@@ -32,7 +32,7 @@ export const ProductDetailInsights = (props: Props) => {
         >
           <RemountOnSiteChange>
             <StaticQuestion
-              questionId="PgajooaC4Bo1lkVnu5jMM"
+              questionId={165}
               height={250}
               initialSqlParameters={{ product_id: props.productId }}
             />
@@ -47,7 +47,7 @@ export const ProductDetailInsights = (props: Props) => {
 
         <RemountOnSiteChange>
           <StaticQuestion
-            questionId="8emcAd9TTrPoHLuaFaUh0"
+            questionId={161}
             height={70}
             initialSqlParameters={{ product_id: props.productId }}
           />
@@ -63,7 +63,7 @@ export const ProductDetailInsights = (props: Props) => {
       >
         <Flex mih={700} className="orders-over-time-container">
           <InteractiveQuestion
-            questionId="jA76uaXQKWC1xp7q2TvE2"
+            questionId={158}
             title={
               <Title fw={400} size="h2" className="product-detail-card-title">
                 Orders over time

--- a/src/routes/product-list/ProductCard.tsx
+++ b/src/routes/product-list/ProductCard.tsx
@@ -45,7 +45,7 @@ export const ProductCard = ({ product }: Props) => {
               <LoadWhenVisible>
                 <RemountOnSiteChange>
                   <StaticQuestion
-                    questionId="8emcAd9TTrPoHLuaFaUh0"
+                    questionId={161}
                     withChartTypeSelector={false}
                     height={questionHeight}
                     initialSqlParameters={{ product_id: product.id }}

--- a/src/store/create.ts
+++ b/src/store/create.ts
@@ -1,8 +1,8 @@
 import { atom } from "jotai"
 
-export const createDashboardIdAtom = atom<string | null>(null)
+export const createDashboardIdAtom = atom<number | null>(null)
 
-export const createQuestionIdAtom = atom<string | undefined>(undefined)
+export const createQuestionIdAtom = atom<number | undefined>(undefined)
 
 export const resetQuestionAtom = atom(null, (_, set) => {
   set(createQuestionIdAtom, undefined)

--- a/src/utils/sidebar-links.tsx
+++ b/src/utils/sidebar-links.tsx
@@ -80,7 +80,7 @@ export function useSidebarLinks(): SidebarLink[] {
             },
           },
           {
-            to: "/admin/analytics/i5s-lcGYLc1GyFdIy4TxH",
+            to: "/admin/analytics/17",
             title: "Inventory performance",
             icons: {
               proficiency: () => (


### PR DESCRIPTION
Reverts #110 as entity IDs are causing flickering on the SDK.

This reverts commit df0b165c1be55f0e2c46888807d5bd20bab4455f, reversing changes made to c1b115c9fd375f73bd66767bfa503c7293b50816.