### PR TITLE
Update SDK to 0.54.8 and use entity ids instead of numeric ids

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@mantine/core": "^7.8.0",
     "@mantine/form": "^7.8.0",
     "@mantine/hooks": "^7.8.0",
-    "@metabase/embedding-sdk-react": "^0.54.7",
+    "@metabase/embedding-sdk-react": "^0.54.8",
     "@tanstack/react-query": "^5.32.0",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",

--- a/src/constants/collections.ts
+++ b/src/constants/collections.ts
@@ -1,17 +1,17 @@
 import { SiteKey } from "../types/site"
 
-export const QUESTION_TEMPLATE_COLLECTION_ID = 42
+export const QUESTION_TEMPLATE_COLLECTION_ID = "wMtVlfN46XKdxw-AE6iEA"
 
-export const SANDBOXED_CUSTOM_ANALYTICS_COLLECTIONS: Record<SiteKey, number> = {
-  stitch: 45,
-  luminara: 46,
-  pug: 47,
-  proficiency: 100,
+export const SANDBOXED_CUSTOM_ANALYTICS_COLLECTIONS: Record<SiteKey, string> = {
+  stitch: "AsgXAPPxfjHkV_bXv1MhA",
+  luminara: "g0FmUQnNqLT6xnJL2bWMF",
+  pug: "3vHp_t-NNNJD9YAs6Vt1j",
+  proficiency: "RJ9Hcd1mqaFKQvZzABB3t",
 }
 
-export const SANDBOXED_USER_GENERATED_COLLECTIONS: Record<SiteKey, number> = {
-  stitch: 48,
-  luminara: 49,
-  pug: 50,
-  proficiency: 101,
+export const SANDBOXED_USER_GENERATED_COLLECTIONS: Record<SiteKey, string> = {
+  stitch: "HPAvJNTD9XTRkwJZUX9Fz",
+  luminara: "FswOnCotqpwb96gqOkYU1",
+  pug: "Il4ywja-XJRgB8VbCzOTb",
+  proficiency: "H8kX2zn3T6KLE44DdgKQ8",
 }

--- a/src/routes/analytics/AnalyticsCustomPage.tsx
+++ b/src/routes/analytics/AnalyticsCustomPage.tsx
@@ -44,9 +44,9 @@ export function AnalyticsCustomPage() {
         className="analytics-collection-browser"
         onClick={(item) => {
           if (item.model === "dashboard") {
-            navigate(`/analytics/${item.id}`)
+            navigate(`/analytics/${item.entity_id}`)
           } else if (item.model === "card") {
-            navigate(`/question/${item.id}`)
+            navigate(`/question/${item.entity_id}`)
           }
         }}
       />

--- a/src/routes/analytics/AnalyticsOverviewPage.tsx
+++ b/src/routes/analytics/AnalyticsOverviewPage.tsx
@@ -14,7 +14,7 @@ export function AnalyticsOverviewPage() {
       <Stack>
         <SimpleGrid cols={{ base: 1, xs: 2, sm: 3, lg: 4 }}>
           {overviewLinkCards.map((card) => (
-            <DashboardLinkCard key={card.id} {...card} />
+            <DashboardLinkCard key={card.entityId} {...card} />
           ))}
         </SimpleGrid>
       </Stack>

--- a/src/routes/analytics/DashboardLinkCard.tsx
+++ b/src/routes/analytics/DashboardLinkCard.tsx
@@ -2,7 +2,7 @@ import { Link } from "wouter"
 import { Text, Card, Box, Title, Flex } from "@mantine/core"
 
 export interface DashboardLinkCardProps {
-  id: number
+  entityId: string
   title: string
   description?: string
   author: string
@@ -11,7 +11,7 @@ export interface DashboardLinkCardProps {
 
 export const DashboardLinkCard = (props: DashboardLinkCardProps) => {
   return (
-    <Link to={`/analytics/${props.id}`}>
+    <Link to={`/analytics/${props.entityId}`}>
       <Card className="card gap-y-5 justify-between" h="100%" withBorder p={12}>
         <Box>
           <Title size="h4">{props.title}</Title>

--- a/src/routes/analytics/DashboardPage.tsx
+++ b/src/routes/analytics/DashboardPage.tsx
@@ -5,19 +5,17 @@ import { useReloadOnSiteChange } from "../../utils/use-site-changed"
 import { withProductClickAction } from "../../utils/metabase-plugins"
 
 interface Props {
-  id: string
+  entity_id: string
 }
 
 export function DashboardPage(props: Props) {
-  const dashboardId = parseInt(props.id, 10)
-
   // When the site changed, reload to apply the site's sandboxed data.
   useReloadOnSiteChange()
 
   return (
     <Box mih="100vh" className="dashboard-container smartscalar">
       <InteractiveDashboard
-        dashboardId={dashboardId}
+        dashboardId={props.entity_id}
         withTitle
         withDownloads={false}
         plugins={{ mapQuestionClickActions: withProductClickAction() }}

--- a/src/routes/analytics/QuestionPage.tsx
+++ b/src/routes/analytics/QuestionPage.tsx
@@ -5,17 +5,15 @@ import { RemountOnSiteChange } from "../../components/RemountOnSiteChange"
 import { withProductClickAction } from "../../utils/metabase-plugins"
 
 interface Props {
-  id: string
+  entity_id: string
 }
 
 export function QuestionPage(props: Props) {
-  const questionId = parseInt(props.id, 10)
-
   return (
     <Container mih="100vh" className="question-container smartscalar">
       <RemountOnSiteChange>
         <InteractiveQuestion
-          questionId={questionId}
+          questionId={props.entity_id}
           plugins={{ mapQuestionClickActions: withProductClickAction() }}
         />
       </RemountOnSiteChange>

--- a/src/routes/analytics/link-cards.ts
+++ b/src/routes/analytics/link-cards.ts
@@ -2,7 +2,7 @@ import { DashboardLinkCardProps } from "./DashboardLinkCard"
 
 export const overviewLinkCards: DashboardLinkCardProps[] = [
   {
-    id: 17,
+    entityId: "i5s-lcGYLc1GyFdIy4TxH",
     title: "Inventory Performance",
     description:
       "Internal analytics dashboard visualizing key performance and inventory metrics for a demo training platform.",
@@ -10,7 +10,7 @@ export const overviewLinkCards: DashboardLinkCardProps[] = [
     date: "3mo",
   },
   {
-    id: 12,
+    entityId: "skc-qdKHq3FbwFLw0sE4c",
     title: "Orders",
     description:
       "An overview of the orders made by customers. The data is delayed by 2-3 day.",
@@ -18,7 +18,7 @@ export const overviewLinkCards: DashboardLinkCardProps[] = [
     date: "3mo",
   },
   {
-    id: 8,
+    entityId: "jcwoxpN2xgLk3agdlbC63",
     title: "Products",
     description:
       "An overview of the products sold by the shop. The data is delayed by 2-3 day.",

--- a/src/routes/analytics/new/NewDashboardPage.tsx
+++ b/src/routes/analytics/new/NewDashboardPage.tsx
@@ -23,7 +23,9 @@ export const NewDashboardPage = () => {
     return (
       <RemountOnSiteChange>
         <CreateDashboardModal
-          onCreate={(dashboard: { id: number }) => setDashboardId(dashboard.id)}
+          onCreate={(dashboard: { entity_id: string }) =>
+            setDashboardId(dashboard.entity_id)
+          }
           initialCollectionId={collectionId}
           onClose={() => navigate("/admin/analytics/custom")}
         />

--- a/src/routes/analytics/new/NewFromScratchPage.tsx
+++ b/src/routes/analytics/new/NewFromScratchPage.tsx
@@ -11,7 +11,7 @@ export const NewFromScratchPage = () => {
       <InteractiveQuestion
         questionId="new"
         onSave={onSaveQuestion}
-        saveToCollection={collectionId}
+        targetCollection={collectionId}
         isSaveEnabled
       />
     </Container>

--- a/src/routes/analytics/new/NewFromTemplatePage.tsx
+++ b/src/routes/analytics/new/NewFromTemplatePage.tsx
@@ -29,7 +29,7 @@ export const NewFromTemplatePage = () => {
         <CollectionBrowser
           collectionId={QUESTION_TEMPLATE_COLLECTION_ID}
           visibleEntityTypes={["question"]}
-          onClick={(item) => setQuestionId(item.id)}
+          onClick={(item) => setQuestionId(item.entity_id)}
         />
       </Container>
     )
@@ -40,7 +40,7 @@ export const NewFromTemplatePage = () => {
       <Container w="100%">
         <InteractiveQuestion
           onSave={onSaveQuestion}
-          saveToCollection={collectionId}
+          targetCollection={collectionId}
           questionId={templateOrSavedQuestionId}
           isSaveEnabled
         />

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -48,7 +48,9 @@ export const Routes = () => (
 
             <Route
               path="/analytics/:id"
-              component={(props) => <DashboardPage id={props.params.id} />}
+              component={(props) => (
+                <DashboardPage entity_id={props.params.id} />
+              )}
             />
 
             <Route
@@ -69,7 +71,7 @@ export const Routes = () => (
 
           <Route
             path="/question/:id"
-            component={(props) => <QuestionPage id={props.params.id} />}
+            component={(props) => <QuestionPage entity_id={props.params.id} />}
           />
         </Route>
 

--- a/src/routes/internal/KitchenSink.tsx
+++ b/src/routes/internal/KitchenSink.tsx
@@ -3,15 +3,10 @@ import { StaticQuestion } from "@metabase/embedding-sdk-react"
 
 import "./kitchen-sink.css"
 
-const questions: number[] = [
-  // bar
-  95,
-
-  // line
-  96,
-
-  // area
-  97,
+const questions: string[] = [
+  "MvyBus_qDW4SC8NshJ6zD",
+  "bYxRH9Yc8qCzh9PK-F-bV",
+  "wvMvO_S0FJlj010YbKOmT",
 ]
 
 export const KitchenSink = () => (
@@ -38,7 +33,10 @@ export const KitchenSink = () => (
       </Title>
 
       <Flex>
-        <StaticQuestion questionId={95} withChartTypeSelector={false} />
+        <StaticQuestion
+          questionId="MvyBus_qDW4SC8NshJ6zD"
+          withChartTypeSelector={false}
+        />
       </Flex>
 
       <Title pb={8} size="h4">
@@ -46,7 +44,10 @@ export const KitchenSink = () => (
       </Title>
 
       <Card w="100%">
-        <StaticQuestion questionId={95} withChartTypeSelector={false} />
+        <StaticQuestion
+          questionId="MvyBus_qDW4SC8NshJ6zD"
+          withChartTypeSelector={false}
+        />
       </Card>
 
       <Title pb={8} size="h4">
@@ -54,7 +55,10 @@ export const KitchenSink = () => (
       </Title>
 
       <Box w="100%">
-        <StaticQuestion questionId={95} withChartTypeSelector={false} />
+        <StaticQuestion
+          questionId="MvyBus_qDW4SC8NshJ6zD"
+          withChartTypeSelector={false}
+        />
       </Box>
 
       <Title pb={8} size="h4">
@@ -62,7 +66,10 @@ export const KitchenSink = () => (
       </Title>
 
       <Box w="100%" bg="white">
-        <StaticQuestion questionId={76} withChartTypeSelector={false} />
+        <StaticQuestion
+          questionId="t07HOjt9YiRHcWnK7XrgE"
+          withChartTypeSelector={false}
+        />
       </Box>
     </Stack>
   </Stack>

--- a/src/routes/product-detail/ProductDetailInsights.tsx
+++ b/src/routes/product-detail/ProductDetailInsights.tsx
@@ -32,7 +32,7 @@ export const ProductDetailInsights = (props: Props) => {
         >
           <RemountOnSiteChange>
             <StaticQuestion
-              questionId={165}
+              questionId="PgajooaC4Bo1lkVnu5jMM"
               height={250}
               initialSqlParameters={{ product_id: props.productId }}
             />
@@ -47,7 +47,7 @@ export const ProductDetailInsights = (props: Props) => {
 
         <RemountOnSiteChange>
           <StaticQuestion
-            questionId={161}
+            questionId="8emcAd9TTrPoHLuaFaUh0"
             height={70}
             initialSqlParameters={{ product_id: props.productId }}
           />
@@ -63,7 +63,7 @@ export const ProductDetailInsights = (props: Props) => {
       >
         <Flex mih={700} className="orders-over-time-container">
           <InteractiveQuestion
-            questionId={158}
+            questionId="jA76uaXQKWC1xp7q2TvE2"
             title={
               <Title fw={400} size="h2" className="product-detail-card-title">
                 Orders over time

--- a/src/routes/product-list/ProductCard.tsx
+++ b/src/routes/product-list/ProductCard.tsx
@@ -45,7 +45,7 @@ export const ProductCard = ({ product }: Props) => {
               <LoadWhenVisible>
                 <RemountOnSiteChange>
                   <StaticQuestion
-                    questionId={161}
+                    questionId="8emcAd9TTrPoHLuaFaUh0"
                     withChartTypeSelector={false}
                     height={questionHeight}
                     initialSqlParameters={{ product_id: product.id }}

--- a/src/store/create.ts
+++ b/src/store/create.ts
@@ -1,8 +1,8 @@
 import { atom } from "jotai"
 
-export const createDashboardIdAtom = atom<number | null>(null)
+export const createDashboardIdAtom = atom<string | null>(null)
 
-export const createQuestionIdAtom = atom<number | undefined>(undefined)
+export const createQuestionIdAtom = atom<string | undefined>(undefined)
 
 export const resetQuestionAtom = atom(null, (_, set) => {
   set(createQuestionIdAtom, undefined)

--- a/src/utils/sidebar-links.tsx
+++ b/src/utils/sidebar-links.tsx
@@ -80,7 +80,7 @@ export function useSidebarLinks(): SidebarLink[] {
             },
           },
           {
-            to: "/admin/analytics/17",
+            to: "/admin/analytics/i5s-lcGYLc1GyFdIy4TxH",
             title: "Inventory performance",
             icons: {
               proficiency: () => (

--- a/yarn.lock
+++ b/yarn.lock
@@ -1334,10 +1334,10 @@
   resolved "https://registry.yarnpkg.com/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz#775374306116d51c0c500b8c4face0f9a04752d8"
   integrity sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==
 
-"@metabase/embedding-sdk-react@^0.54.7":
-  version "0.54.7"
-  resolved "https://registry.yarnpkg.com/@metabase/embedding-sdk-react/-/embedding-sdk-react-0.54.7.tgz#a540a8c3cc8014b94a0091edb7c4c3fcb46c416c"
-  integrity sha512-/zT243mIyszHUfNh3vnvybup2Ddsnh7y5EBSaYfPowM5Ms2nZKM4NtBwNSGIY7Mt4VrqaMiTFivyfwMV0z8O9g==
+"@metabase/embedding-sdk-react@^0.54.8":
+  version "0.54.8"
+  resolved "https://registry.yarnpkg.com/@metabase/embedding-sdk-react/-/embedding-sdk-react-0.54.8.tgz#77c985ba043e69ab2c82bc530bc00a623c2f69b3"
+  integrity sha512-cRG41+6yUj45l6S5YA5Yhs2Eo2vxI5ljEexGIIz5e3bLgLUamyNR8lN8zg//VnZl/+Ragj48CYYONHh3Z+2JsA==
   dependencies:
     "@codemirror/autocomplete" "^6.18.3"
     "@codemirror/lang-html" "^6.4.9"
@@ -7460,16 +7460,7 @@ string-argv@~0.3.2:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.2.tgz#2b6d0ef24b656274d957d54e0a4bbf6153dc02b6"
   integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -7557,14 +7548,7 @@ stringify-entities@^4.0.0:
     character-entities-html4 "^2.0.0"
     character-entities-legacy "^3.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==


### PR DESCRIPTION
Update SDK to 0.54.8 and use entity ids instead of numeric ids

After https://github.com/metabase/metabase/pull/57073 we can use entity ids without flickering