### PR TITLE
Add vercelignore to avoid adding api/drizzle as Vercel Functions

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,1 @@
+api/drizzle/**


### PR DESCRIPTION
Add vercelignore to avoid adding api/drizzle as Vercel Functions