### PR TITLE
Remove `import of serialized data` fallback when running MB instance in Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,12 @@ If you cannot use the hosted JWT server, you can run the JWT server locally.
 - Run the React frontend.
 
   - `yarn dev:link && yarn dev`
+
+### Running e2e tests
+
+To run e2e tests locally, a proper App DB dump of the Shoppy's Metabase Instance must be placed to the `./local-dist/metabase_dump.sql`
+
+You can get it by:
+- Enabling the `Tailscale`
+- Running `pg_dump "postgres://{{ username }}:{{ password }}@{{ host }}:{{ port }}/{{ database }}" > ./local-dist/metabase_dump.sql` command.
+  - See the `Shoppy Coredev Appdb` record in `1password` for credentials.

--- a/metabase/Dockerfile
+++ b/metabase/Dockerfile
@@ -14,7 +14,8 @@ RUN if [ -f ./app/local-dist/metabase_dump.sql ]; then \
       echo "Local metabase_dump.sql is found in ./app/local-dist, copying it..."; \
       cp ./app/local-dist/metabase_dump.sql /app/metabase_dump.sql; \
     else \
-      echo "Local metabase_dump.sql is not found in ./app/local-dist, skipping copy"; \
+      echo "Local metabase_dump.sql is not found in ./app/local-dist, exiting..."; \
+      exit 1; \
     fi
 
 RUN chmod +x /app/entrypoint.sh

--- a/metabase/entrypoint.sh
+++ b/metabase/entrypoint.sh
@@ -3,26 +3,24 @@ set -e
 
 DUMP=./app/metabase_dump.sql
 
-if [ -f $DUMP ]; then
-  echo "Restoring MB App DB from dump...";
+echo "Restoring MB App DB from dump...";
 
-  METABASE_APP_DB_URL="postgres://${MB_DB_USER}:${MB_DB_PASS}@${MB_DB_HOST}:${MB_DB_PORT}/${MB_DB_DBNAME}"
-  METABASE_APP_DB_DUMP_TYPE=$(file --brief --mime-type "$DUMP")
+METABASE_APP_DB_URL="postgres://${MB_DB_USER}:${MB_DB_PASS}@${MB_DB_HOST}:${MB_DB_PORT}/${MB_DB_DBNAME}"
+METABASE_APP_DB_DUMP_TYPE=$(file --brief --mime-type "$DUMP")
 
-  case "$METABASE_APP_DB_DUMP_TYPE" in
-    application/x-tar|application/octet-stream)
-      echo "Custom　or directory‑format archive → pg_restore"
-      pg_restore -d "$METABASE_APP_DB_URL" "$DUMP" --no-owner > /dev/null
-      ;;
-    text/plain)
-      echo "Plain text SQL → psql"
-      psql "$METABASE_APP_DB_URL" -f "$DUMP" --quiet
-      ;;
-    *)
-      echo "Unknown dump format..."
-      ;;
-  esac
-fi
+case "$METABASE_APP_DB_DUMP_TYPE" in
+  application/x-tar|application/octet-stream)
+    echo "Custom　or directory‑format archive → pg_restore"
+    pg_restore -d "$METABASE_APP_DB_URL" "$DUMP" --no-owner > /dev/null
+    ;;
+  text/plain)
+    echo "Plain text SQL → psql"
+    psql "$METABASE_APP_DB_URL" -f "$DUMP" --quiet
+    ;;
+  *)
+    echo "Unknown dump format..."
+    ;;
+esac
 
 ./app/run_metabase.sh "$@" &
 SERVER_PID=$!
@@ -33,21 +31,5 @@ until curl -s http://metabase:${MB_JETTY_PORT}/api/health | grep -q "\"status\":
 done
 
 echo "Metabase is healthy. Running additional configuration..."
-
-if [ ! -f ./app/metabase_dump.sql ]; then
-  echo "Running import...";
-
-  SESSION_ID=$(curl -s -X POST \
-    -H "Content-Type: application/json" \
-    -d "{\"username\": \"${METABASE_ADMIN_EMAIL}\", \"password\": \"${METABASE_ADMIN_PASSWORD}\"}" \
-    http://metabase:${MB_JETTY_PORT}/api/session | sed -n 's/.*"id":"\([^"]*\)".*/\1/p')
-
-  curl -X POST \
-    -H "X-Metabase-Session: $SESSION_ID" \
-    -F file=@./app/metabase_data.tar.gz \
-    http://metabase:${MB_JETTY_PORT}/api/ee/serialization/import
-fi
-
-echo "Import complete. Keeping the server running..."
 
 wait $SERVER_PID


### PR DESCRIPTION
It allows us writing e2e tests covering Sandboxing

How to verify:
- e2e should pass