### PR TITLE
Use the `main` branch for Shoppy Deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ on:
     types:
       - completed
     branches:
-      - "release"
+      - "main"
 
 env:
   version: ${{ github.event.inputs.version || vars.MB_VERSION }}
@@ -25,8 +25,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          ref: "release"
       - name: Tailscale
         uses: tailscale/github-action@v2
         with:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -4,12 +4,10 @@ on:
   push:
     branches:
       - "main"
-      - "release"
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - "main"
-      - "release"
 
 jobs:
   e2e-tests:

--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ If you cannot use the hosted JWT server, you can run the JWT server locally.
 
   - `yarn dev:link && yarn dev`
 
-### Running e2e tests
+### Running e2e tests (For Metabase developers)
 
 To run e2e tests locally, a proper App DB dump of the Shoppy's Metabase Instance must be placed to the `./local-dist/metabase_dump.sql`
 
 You can get it by:
-- Enabling the `Tailscale`
+- Enabling the `Tailscale` and logging in using your work email address.
 - Running `pg_dump "postgres://{{ username }}:{{ password }}@{{ host }}:{{ port }}/{{ database }}" > ./local-dist/metabase_dump.sql` command.
   - See the `Shoppy Coredev Appdb` record in `1password` for credentials.


### PR DESCRIPTION
Use the `main` branch for Shoppy Deployment

Verify:
- CI is green