### PR TITLE
Fix Shoppy's custom click behavior not working

### DIFF
--- a/src/utils/metabase-plugins.tsx
+++ b/src/utils/metabase-plugins.tsx
@@ -3,8 +3,8 @@ import { MetabaseClickActionPluginsConfig } from "@metabase/embedding-sdk-react"
 import { productIdForClickActionModalAtom } from "../store/click-actions"
 import { store } from "../store"
 
-const ORDERS_TABLE_ID = 53
-const PRODUCTS_TABLE_ID = 45
+const ORDERS_TABLE_ID = 38
+const PRODUCTS_TABLE_ID = 37
 
 export const withProductClickAction =
   ({


### PR DESCRIPTION
Fix [EMB-372](https://linear.app/metabase/issue/EMB-372/shoppy-mapquestionclickactions-not-working-anymore)

This updates the table IDs to be the latest ones. Then the `See this project` custom click action item would show up.

![image](https://github.com/user-attachments/assets/9c9565d3-2295-493a-9ab0-4bfe3e8a2f0b)

#### How to verify
Click Site 1 > Inventory performance Dashboard > at the bottom Orders table for the ID column. Or just simply visit [this link](https://shoppy-phfeossfl-embedding-c312e713.vercel.app/admin/analytics/i5s-lcGYLc1GyFdIy4TxH). And click on the bottom Orders table.

#### Note

IDs are grabbed by observing the queries

![Screenshot 2025-05-02 at 3 30 17 PM](https://github.com/user-attachments/assets/d22ba43b-3c2a-4f88-950e-e68dfa6813e0)

![Screenshot 2025-05-02 at 3 29 43 PM](https://github.com/user-attachments/assets/aa6a465a-b43f-4f27-8887-504e5eb47d5f)
