### PR TITLE
Fix theStitch dark mode theming regressions

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@mantine/core": "^7.8.0",
     "@mantine/form": "^7.8.0",
     "@mantine/hooks": "^7.8.0",
-    "@metabase/embedding-sdk-react": "^0.54.8",
+    "@metabase/embedding-sdk-react": "^0.54.9",
     "@tanstack/react-query": "^5.32.0",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",

--- a/src/routes/product-list/ProductCardFooter.tsx
+++ b/src/routes/product-list/ProductCardFooter.tsx
@@ -19,7 +19,7 @@ export function ProductCardFooter() {
   }
 
   return (
-    <Button w="fit-content" className="themed-button" ml="8px" mt="xs">
+    <Button w="fit-content" className="themed-button" ml="8px" mt="md">
       See more
     </Button>
   )

--- a/src/themes/stitch.css
+++ b/src/themes/stitch.css
@@ -22,8 +22,15 @@ body[data-theme="stitch"] {
     -webkit-text-fill-color: transparent;
   }
 
-  .sidebar-inactive-child:hover {
+  .sidebar-inactive-child,
+  .sidebar-link-parent {
     color: var(--color-light-grey);
+  }
+
+  .sidebar-inactive-child:hover,
+  .sidebar-link-parent:hover {
+    color: #fff;
+    background: transparent;
   }
 
   .themed-button {

--- a/src/themes/stitch.ts
+++ b/src/themes/stitch.ts
@@ -81,6 +81,12 @@ const metabase: MetabaseTheme = {
         backgroundColor: colors.darkGrey,
       },
     },
+    table: {
+      cell: {
+        // TODO: this should not be required! needs a fix in the embedding sdk to restore cell defaults.
+        backgroundColor: "#212426",
+      },
+    },
   },
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1334,10 +1334,10 @@
   resolved "https://registry.yarnpkg.com/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz#775374306116d51c0c500b8c4face0f9a04752d8"
   integrity sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==
 
-"@metabase/embedding-sdk-react@^0.54.8":
-  version "0.54.8"
-  resolved "https://registry.yarnpkg.com/@metabase/embedding-sdk-react/-/embedding-sdk-react-0.54.8.tgz#77c985ba043e69ab2c82bc530bc00a623c2f69b3"
-  integrity sha512-cRG41+6yUj45l6S5YA5Yhs2Eo2vxI5ljEexGIIz5e3bLgLUamyNR8lN8zg//VnZl/+Ragj48CYYONHh3Z+2JsA==
+"@metabase/embedding-sdk-react@^0.54.9":
+  version "0.54.9"
+  resolved "https://registry.yarnpkg.com/@metabase/embedding-sdk-react/-/embedding-sdk-react-0.54.9.tgz#c8bee7b0d3653e932ab4611a82f8300de6989c68"
+  integrity sha512-Iz3VUFfTXy7BZpOBdGK7hFVX2i6ACzjP5IXVSKawGti4pYNGLstZOZbBH0xNp/O9EkQ2OrRDb7CNi6ngWPrJow==
   dependencies:
     "@codemirror/autocomplete" "^6.18.3"
     "@codemirror/lang-html" "^6.4.9"
@@ -7460,7 +7460,16 @@ string-argv@~0.3.2:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.2.tgz#2b6d0ef24b656274d957d54e0a4bbf6153dc02b6"
   integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -7548,7 +7557,14 @@ stringify-entities@^4.0.0:
     character-entities-html4 "^2.0.0"
     character-entities-legacy "^3.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==


### PR DESCRIPTION
Closes [EMB-375](https://linear.app/metabase/issue/EMB-375/shoppy-thestitch-dark-mode-theming-regressions)

### 1. The hover color for theStitch's sidebar looks broken.

Design:

<img src="https://github.com/user-attachments/assets/4b467857-d319-43c4-b302-69406d320004" width="300">

Current:

<img src="https://github.com/user-attachments/assets/37e39b1a-081f-4bb5-b8a7-844f33adbf76" width="300">

After Fix:

<img src="https://github.com/user-attachments/assets/15b2cf0a-a1cd-4fbf-9b9a-206065d7c186" width="300">

### 2. Tables looks really broken in theStitch dark mode.

This is actually an issue with the SDK itself not using the table cell fallback after the data table revamp. Let's hotfix first since it looks really really bad 😭

Current:

![CleanShot 2568-05-02 at 23 58 33@2x](https://github.com/user-attachments/assets/a477f8ee-2fc5-4d2a-a08a-18f53ae2eaaf)

After Fix:

![CleanShot 2568-05-02 at 23 58 53@2x](https://github.com/user-attachments/assets/ef6a91ad-37e9-4a77-8385-ec32f66ecb40)

### 3. See more needs more spacing

Current:

<img src="https://github.com/user-attachments/assets/12911444-a63d-43ec-bd2d-c4d921a95624" width="300">

After Fix:

<img src="https://github.com/user-attachments/assets/c101cc43-fd02-4e36-9fe8-913d22d3cd53" width="300">
