### PR TITLE
Fix seeding data types and adjust docker commands

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -19,3 +19,5 @@ SHOPPY_DB_PORT="5432"
 SHOPPY_DB="shoppy"
 SHOPPY_DB_USER="shoppy"
 SHOPPY_DB_PASSWORD="foobarbaz"
+
+WATCH="false"

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN if [ "$WATCH" != "true" ]; then \
       echo "WATCH env is not set; running production yarn build..."; \
       yarn build; \
     else \
-      echo "WATCH env iss is set; running in development mode..."; \
+      echo "WATCH env is set; running in development mode..."; \
     fi
 
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,23 @@
 
 FROM node:22-bullseye AS runner
 
+ENV NODE_OPTIONS="--max-old-space-size=4096"
+
+ARG VITE_APP_METABASE_INSTANCE_URL
+ENV VITE_APP_METABASE_INSTANCE_URL=${VITE_APP_METABASE_INSTANCE_URL}
+
+ARG VITE_APP_API_HOST
+ENV VITE_APP_API_HOST=${VITE_APP_API_HOST}
+
+ARG VITE_APP_AUTH_PROVIDER_URI
+ENV VITE_APP_AUTH_PROVIDER_URI=${VITE_APP_AUTH_PROVIDER_URI}
+
+ARG WATCH=false
+ENV WATCH=${WATCH}
+
 WORKDIR /app
 
-COPY --exclude=./api . .
+COPY --exclude=./api --exclude=./metabase . .
 
 RUN yarn --frozen-lockfile
 
@@ -15,4 +29,11 @@ RUN if [ -d "./local-dist/embedding-sdk" ]; then \
       echo "Local embedding-sdk dist is not found in ./local-dist/embedding-sdk, skipping copy"; \
     fi
 
-CMD ["yarn", "dev", "--host"]
+RUN if [ "$WATCH" != "true" ]; then \
+      echo "WATCH env is not set; running production yarn build..."; \
+      yarn build; \
+    else \
+      echo "WATCH env iss is set; running in development mode..."; \
+    fi
+
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ This demo uses the data from the hosted Metabase Cloud instance and provides a h
 > The following sections are for Metabase employees who are working on the embedding SDK.
 > If you are not a Metabase employee, you can skip the following sections.
 
+### Using an existing running MB instance
+
 - Place the metabase repository in `../metabase`
 
 - Open a new terminal and run `yarn build-release:cljs && yarn build-embedding-sdk:watch` in the metabase repository. This watches for changes and builds the embedding SDK in development mode.
@@ -35,6 +37,15 @@ This demo uses the data from the hosted Metabase Cloud instance and provides a h
 - Re-run the following command every time you make changes to the embedding SDK's source. This re-links the built SDK to the demo application.
 
   - `yarn dev:link && yarn dev`
+
+### Using Docker
+
+- Clone `.env.docker.example` to `.env.docker` and set the proper `PREMIUM_EMBEDDING_TOKEN` value.
+- If you want to test a local Embedding SDK version, copy it to the `local-dist/embedding-sdk` folder.
+- Run Docker via `yarn docker:up` for the `production` build or `WATCH=true yarn docker:up` for the development build with the `watch` support.
+  - The command launches containers with the local MB instance, Shoppy DWH, Shoppy API and Shoppy Client.
+  - Visit `http://localhost:4400`.
+- To stop containers run `yarn docker:down`.
 
 ### How to run the demo against a local JWT auth server?
 

--- a/api/drizzle/seeder/generate-people.ts
+++ b/api/drizzle/seeder/generate-people.ts
@@ -40,7 +40,7 @@ export async function generatePeople() {
       state: faker.location.state(),
       source: faker.internet.domainName(),
       birthDate: faker.date.birthdate().toString(),
-      zip: parseInt(faker.location.zipCode()),
+      zip: faker.location.zipCode("#####"),
       latitude: faker.location.latitude().toString(),
       shopId,
       createdAt,

--- a/api/src/schema/people.ts
+++ b/api/src/schema/people.ts
@@ -1,4 +1,4 @@
-import { pgTable, bigint, text } from "drizzle-orm/pg-core"
+import { pgTable, date, timestamp, bigint, text } from "drizzle-orm/pg-core"
 import { shops } from "./shops"
 
 export const people = pgTable("people", {
@@ -11,10 +11,15 @@ export const people = pgTable("people", {
   longitude: text("longitude"),
   state: text("state"),
   source: text("source"),
-  birthDate: text("birth_date"),
-  zip: bigint("zip", { mode: "number" }),
+  birthDate: date("birth_date"),
+  zip: text("zip"),
   latitude: text("latitude"),
-  createdAt: text("created_at"),
+  createdAt: timestamp("created_at", {
+    withTimezone: true,
+    mode: "string",
+  })
+    .defaultNow()
+    .notNull(),
   shopId: bigint("shop_id", { mode: "number" })
     .notNull()
     .references(() => shops.id),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,11 +105,17 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        VITE_APP_METABASE_INSTANCE_URL: "http://localhost:${MB_PORT}"
+        VITE_APP_API_HOST: "http://localhost:${API_PORT}/api"
+        VITE_APP_AUTH_PROVIDER_URI: "/sso/metabase"
+        WATCH: '${WATCH}'
     environment:
       CLIENT_PORT: "${CLIENT_PORT}"
       VITE_APP_METABASE_INSTANCE_URL: "http://localhost:${MB_PORT}"
       VITE_APP_API_HOST: "http://localhost:${API_PORT}/api"
       VITE_APP_AUTH_PROVIDER_URI: "/sso/metabase"
+      WATCH: '${WATCH}'
     ports:
       - "${CLIENT_PORT}:${CLIENT_PORT}"
     volumes:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+if [ "$WATCH" = "true" ]; then
+  yarn dev --host
+else
+  yarn preview --host
+fi


### PR DESCRIPTION
Fix seeding data types and adjust docker commands

> People
> - Birthdate should be date
> - Zip should be text
> - Created at should timestamp or datetime


The `Lat long are both text sbut should be both stored as postgis points (does MB handle that well? guess so?)` is still under the question.

Also adjusted docker build process to handle `WATCH` ENV flag, so now in Docker app can be built in the `production` mode