### PR TITLE
Increase timeout for e2e tests

### DIFF
--- a/e2e/test/compatibility.cy.spec.js
+++ b/e2e/test/compatibility.cy.spec.js
@@ -1,4 +1,4 @@
-const TIMEOUT = 20000
+const TIMEOUT = 40000
 
 describe("Embedding SDK: shoppy compatibility", () => {
   it("should open an Interactive Dashboard", () => {


### PR DESCRIPTION
We need it for `dev` bundle of a sample app testing.