### PR TITLE
Define MB_JWT_IDENTITY_PROVIDER_URI

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,6 +73,7 @@ services:
       MB_EDITION: "ee"
       MB_SITE_URL: "http://localhost:${MB_PORT}/"
       MB_PREMIUM_EMBEDDING_TOKEN: "${PREMIUM_EMBEDDING_TOKEN}"
+      MB_JWT_IDENTITY_PROVIDER_URI: "http://localhost:${API_PORT}/sso/metabase"
       MB_JWT_SHARED_SECRET: "${METABASE_JWT_SHARED_SECRET}"
       MB_SETUP_TOKEN: "${PREMIUM_EMBEDDING_TOKEN}"
       MB_DB_TYPE: "postgres"


### PR DESCRIPTION
We need it only for local testing cases when MB is initialized not from a PG dump, but from a serialized data snapshot

How to verify:
- CI should pass