### PR TITLE
Update embedded Metabot layout

### DIFF
--- a/src/components/layout/Shell.tsx
+++ b/src/components/layout/Shell.tsx
@@ -10,6 +10,7 @@ import {
 import { useDisclosure } from "@mantine/hooks"
 import { ReactNode } from "react"
 import { Icon } from "@iconify/react"
+import { usePathname } from "wouter/use-browser-location"
 
 import { SidebarLinks } from "./SidebarLinks"
 
@@ -36,6 +37,28 @@ export function Shell(props: Props) {
 
   const [isSiteReloading] = useAtom(siteIsReloadingAtom)
 
+  const path = usePathname()
+  const isMetabotLayout = path.endsWith("/ask-metabot")
+
+  function getMainContentLayout() {
+    // For Metabot layout, hide the gradient and footer.
+    if (isMetabotLayout) {
+      return props.children
+    }
+
+    return (
+      <>
+        <ProficiencyGradient />
+
+        <Stack h="100%" py="xl">
+          <Box className="flex-1">{props.children}</Box>
+
+          <SiteFooter />
+        </Stack>
+      </>
+    )
+  }
+
   if (isSiteReloading) {
     return <FullPageLoader />
   }
@@ -56,6 +79,7 @@ export function Shell(props: Props) {
       padding="sm"
       classNames={{
         navbar: "navbar overflow-scroll sm:overflow-visible",
+        main: isMetabotLayout ? "app-shell-remove-padding" : "",
       }}
     >
       <AppShell.Header zIndex={102} bg="#2B2F32" className="border-none">
@@ -155,13 +179,7 @@ export function Shell(props: Props) {
       </AppShell.Navbar>
 
       <AppShell.Main h="100dvh">
-        <ProficiencyGradient />
-
-        <Stack h="100%" py="xl">
-          <Box className="flex-1">{props.children}</Box>
-
-          <SiteFooter />
-        </Stack>
+        {getMainContentLayout()}
 
         <ClickActionDemoModal />
       </AppShell.Main>

--- a/src/components/layout/Shell.tsx
+++ b/src/components/layout/Shell.tsx
@@ -38,7 +38,7 @@ export function Shell(props: Props) {
   const [isSiteReloading] = useAtom(siteIsReloadingAtom)
 
   const path = usePathname()
-  const isMetabotLayout = path.endsWith("/ask-metabot")
+  const isMetabotLayout = path.includes("/analytics/new/ask-metabot")
 
   function getMainContentLayout() {
     // For Metabot layout, hide the gradient and footer.

--- a/src/routes/analytics/new/NewAskMetabotPage.tsx
+++ b/src/routes/analytics/new/NewAskMetabotPage.tsx
@@ -1,10 +1,5 @@
-import { Container } from "@mantine/core"
 import { MetabotQuestion } from "@metabase/embedding-sdk-react"
 
 export const NewAskMetabotPage = () => {
-  return (
-    <Container w="100%">
-      <MetabotQuestion />
-    </Container>
-  )
+  return <MetabotQuestion height="100%" />
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -74,3 +74,6 @@ body:not([data-theme="luminara"]) {
   @apply space-y-3;
 }
 
+.app-shell-remove-padding {
+  --app-shell-padding: 0px;
+}


### PR DESCRIPTION
Closes EMB-889

Use full-width layout per design, and hide the footer and gradients.

[Design](https://www.figma.com/design/l9y9OEENQUYiKSbFo7WQA0/Embedding-Metabot-w--SDK-to-ask-questions-using-natural-language?node-id=17431-5559&t=gPnlO5lJ7DcZYT1Q-1):

<img width="1174" height="686" alt="CleanShot 2568-10-07 at 19 56 52@2x" src="https://github.com/user-attachments/assets/90e7ee8e-ab7f-4455-8a8f-2465d0ab816f" />

Before:

<img width="2550" height="1776" alt="CleanShot 2568-10-07 at 19 57 36@2x" src="https://github.com/user-attachments/assets/f797ceca-a16b-4090-ab8a-f94bde211b9c" />

After:

<img width="2552" height="1782" alt="CleanShot 2568-10-07 at 19 57 49@2x" src="https://github.com/user-attachments/assets/15d72c22-870c-4451-bed9-625b17a1d150" />
