### PR TITLE
Update hover color for proficiency labs

### DIFF
--- a/src/themes/proficiency.ts
+++ b/src/themes/proficiency.ts
@@ -40,7 +40,7 @@ const metabase: MetabaseTheme = {
     "text-tertiary": "rgba(0, 0, 0, 0.4)",
     border: "rgba(0, 0, 0, 0.12)",
     background: colors.background,
-    "background-hover": "#fCFDFD",
+    "background-hover": "#F1F0FA",
     "background-disabled": "rgba(0, 0, 0, 0.1)",
     charts: [
       colors.primary,


### PR DESCRIPTION
We were using a near-white #FCFDFD color. Let's change it to a legible purple color. See the hovered "Row" menu.

<img width="1928" height="1160" alt="CleanShot 2568-10-08 at 21 40 28@2x" src="https://github.com/user-attachments/assets/97e2afc4-7f58-4627-a586-b2929cb11a71" />
