### PR TITLE
Hotfix: remove lazy loading to fix embedding demo crash

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -43,6 +43,14 @@ jobs:
           cp .env.docker.example .env.docker &&
           yarn docker:e2e:up --wait
 
+      - name: Dump container logs on failure
+        if: failure()
+        run: |
+          echo "=== shoppy-metabase-1 logs ===" && docker logs shoppy-metabase-1 2>&1 || true
+          echo "=== shoppy-api-1 logs ===" && docker logs shoppy-api-1 2>&1 || true
+          echo "=== shoppy-client-1 logs ===" && docker logs shoppy-client-1 2>&1 || true
+          echo "=== Container statuses ===" && docker ps -a 2>&1 || true
+
       - name: Install Chrome v111
         uses: browser-actions/setup-chrome@v1
         with:

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -1,6 +1,6 @@
 services:
   metabase:
-    image: metabase/metabase-enterprise:v1.58.x
+    image: metabase/metabase-enterprise:v1.59.x
     volumes:
       - type: bind
         source: ./metabase/metabase_dump.sql

--- a/src/routes/product-list/ProductCard.tsx
+++ b/src/routes/product-list/ProductCard.tsx
@@ -8,7 +8,6 @@ import { Product } from "../../types/product"
 import { RemountOnSiteChange } from "../../components/RemountOnSiteChange"
 import { siteAtom } from "../../store/site"
 import { truncate } from "../../utils/truncate"
-import { LoadWhenVisible } from "../../components/LoadWhenVisible"
 import { LinkWithSearchParams } from "../../components/LinkWithSearchParams"
 
 interface Props {
@@ -41,16 +40,14 @@ export const ProductCard = ({ product }: Props) => {
             </Text>
 
             <Box py={4} h={questionHeight}>
-              <LoadWhenVisible>
-                <RemountOnSiteChange>
-                  <StaticQuestion
-                    questionId="8emcAd9TTrPoHLuaFaUh0"
-                    withChartTypeSelector={false}
-                    height={questionHeight}
-                    initialSqlParameters={{ product_id: product.id }}
-                  />
-                </RemountOnSiteChange>
-              </LoadWhenVisible>
+              <RemountOnSiteChange>
+                <StaticQuestion
+                  questionId="8emcAd9TTrPoHLuaFaUh0"
+                  withChartTypeSelector={false}
+                  height={questionHeight}
+                  initialSqlParameters={{ product_id: product.id }}
+                />
+              </RemountOnSiteChange>
             </Box>
 
             <ProductCardFooter />

--- a/src/routes/product-list/index.tsx
+++ b/src/routes/product-list/index.tsx
@@ -59,7 +59,7 @@ export const ProductAnalyticsPage = (props: Props) => {
           spacing="xl"
           verticalSpacing={VERTICAL_SPACING[site]}
         >
-          {products.map((product) => (
+          {products.slice(0, 7).map((product) => (
             <ProductCard key={product.id} product={product} />
           ))}
         </SimpleGrid>


### PR DESCRIPTION
Fixes [EMB-1425: Hotfix Shoppy demo app lazy loading crash](https://linear.app/metabase/issue/EMB-1425/hotfix-shoppy-demo-app-lazy-loading-crash)

Obviously a temporary hot-fix. Real fix is at 1426. Read about [the root cause here](https://github.com/metabase/metabase/issues/70763) - it's interesting to say the least.

## Summary

- Remove the `IntersectionObserver`-based `LoadWhenVisible` lazy loader from `ProductCard` to prevent the embedding demo marketing page from crashing
- Limit the product list to 7 items to match normal page load behavior

## How to test

1. Create this HTML file and serve it locally. You will see two collapsibles.

```html
<details>
  <summary>Production Shoppy</summary>
  <iframe src="https://embedded-analytics-sdk-demo.metabase.com/admin/products" width="400px" height="1000px" style="border: none"></iframe>
</details>

<details>
  <summary>Test Branch Shoppy</summary>
  <iframe src="https://shoppy-oonefofdb-embedding-c312e713.vercel.app/admin/products" width="400px" height="1000px" style="border: none"></iframe>
</details>
```

2. **IMPORTANT: Wait 6 seconds.** - if you don't wait until it loads, it will NOT crash!
3. Open the first collapsible (production) - it will crash and the page will become blank
4. Reload the page. **Wait 5 - 6 seconds again.**
5. Open the second collapsible (this branch) - it will not crash

## Test plan
- [ ] Verify the embedding demo page (second tab) loads without crashing on Chromium and Safari
- [ ] Verify product cards render their StaticQuestion trend data immediately
- [ ] Verify no more than 7 products are shown in the product list

🤖 Generated with [Claude Code](https://claude.com/claude-code)