### PR TITLE
reverted border colors

### DIFF
--- a/src/themes/luminara.ts
+++ b/src/themes/luminara.ts
@@ -39,7 +39,7 @@ const metabase: MetabaseTheme = {
     "text-primary": colors.green3,
     "text-secondary": colors.green3,
     "text-tertiary": colors.green3,
-    border: "transparent",
+    border: colors.green1,
     background: colors.background,
     "background-secondary": colors.background,
     "background-hover": colors.background,

--- a/src/themes/proficiency.ts
+++ b/src/themes/proficiency.ts
@@ -38,7 +38,7 @@ const metabase: MetabaseTheme = {
     "text-primary": colors.lightGrey,
     "text-secondary": colors.lightGrey,
     "text-tertiary": "rgba(0, 0, 0, 0.4)",
-    border: "transparent",
+    border: "rgba(0, 0, 0, 0.12)",
     background: colors.background,
     "background-hover": "#EDF7F6",
     "background-disabled": "rgba(0, 0, 0, 0.1)",

--- a/src/themes/pug.ts
+++ b/src/themes/pug.ts
@@ -39,7 +39,7 @@ const metabase: MetabaseTheme = {
     "text-primary": colors.darkGrey,
     "text-secondary": colors.lightGrey,
     "text-tertiary": colors.lightGrey,
-    border: "transparent",
+    border: "#3B3F3F",
     background: colors.background,
     "background-hover": "#FCFAF1",
     "background-disabled": colors.lighterGrey,

--- a/src/themes/stitch.ts
+++ b/src/themes/stitch.ts
@@ -39,7 +39,7 @@ const metabase: MetabaseTheme = {
     "text-primary": colors.lighterGrey,
     "text-secondary": colors.lighterGrey,
     "text-tertiary": colors.lightGrey,
-    border: "transparent",
+    border: colors.darkGrey,
     background: colors.background,
     "background-secondary": colors.darkGrey,
     "background-hover": colors.background,


### PR DESCRIPTION
Closes [EMB-1686: Divider missing between chat and results in Shoppy](https://linear.app/metabase/issue/EMB-1686/divider-missing-between-chat-and-results-in-shoppy)
<img width="1639" height="741" alt="SCR-20260505-pbzw" src="https://github.com/user-attachments/assets/78f70aee-58aa-4d59-b038-fd0eca15cf8d" />
<img width="1639" height="741" alt="SCR-20260505-pbzp" src="https://github.com/user-attachments/assets/2e01b763-6ba8-4680-9e62-2e3b92e33845" />
<img width="1639" height="741" alt="SCR-20260505-pbzh" src="https://github.com/user-attachments/assets/38a25ca8-196c-4626-b417-b7adee1f4b1b" />
<img width="1639" height="741" alt="SCR-20260505-pbyw" src="https://github.com/user-attachments/assets/d697fd89-47f9-4f72-95e5-4b52a83a64a7" />

