### PR TITLE
Force reindex before compatibility tests run

### DIFF
--- a/e2e/support/helpers/sign-in.js
+++ b/e2e/support/helpers/sign-in.js
@@ -1,0 +1,64 @@
+// TODO (Kelvin 2026-07-07) bandage, not a fix (EMB-2059) — see compatibility.cy.spec.js.
+
+export const METABASE_URL = "http://localhost:4300"
+
+// JWT_SHARED_SECRET also appears in .env.docker.example, so it's not a real secret.
+const JWT_SHARED_SECRET =
+  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+const ADMIN_EMAIL = "shoppy@metabase.com"
+
+function base64url(bytes) {
+  let binary = ""
+  new Uint8Array(bytes).forEach((byte) => {
+    binary += String.fromCharCode(byte)
+  })
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "")
+}
+
+async function getSignedJwtForAdmin() {
+  const encoder = new TextEncoder()
+  const header = { alg: "HS256", typ: "JWT" }
+  const payload = {
+    email: ADMIN_EMAIL,
+    first_name: "Shoppy",
+    last_name: "Admin",
+    exp: Math.floor(Date.now() / 1000) + 600,
+  }
+  const signingInput = `${base64url(encoder.encode(JSON.stringify(header)))}.${base64url(
+    encoder.encode(JSON.stringify(payload)),
+  )}`
+
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(JWT_SHARED_SECRET),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  )
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    encoder.encode(signingInput),
+  )
+
+  return `${signingInput}.${base64url(signature)}`
+}
+
+// Sending the embedding-SDK client header makes /auth/sso return the session id directly in the
+// JSON response body (see generate-response-token in
+// enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj), instead of redirecting
+// with a Set-Cookie header. cy.request() doesn't reliably persist cookies across origins/ports it
+// hasn't cy.visit()-ed, so the JSON path is what actually works here.
+export function signInAsAdmin() {
+  return cy
+    .wrap(getSignedJwtForAdmin())
+    .then((jwt) =>
+      cy.request({
+        method: "GET",
+        url: `${METABASE_URL}/auth/sso`,
+        qs: { jwt },
+        headers: { "X-Metabase-Client": "embedding-sdk-react" },
+      }),
+    )
+    .then(({ body }) => body.id)
+}

--- a/e2e/support/helpers/sign-in.js
+++ b/e2e/support/helpers/sign-in.js
@@ -44,11 +44,6 @@ async function getSignedJwtForAdmin() {
   return `${signingInput}.${base64url(signature)}`
 }
 
-// Sending the embedding-SDK client header makes /auth/sso return the session id directly in the
-// JSON response body (see generate-response-token in
-// enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj), instead of redirecting
-// with a Set-Cookie header. cy.request() doesn't reliably persist cookies across origins/ports it
-// hasn't cy.visit()-ed, so the JSON path is what actually works here.
 export function signInAsAdmin() {
   return cy
     .wrap(getSignedJwtForAdmin())

--- a/e2e/test/compatibility.cy.spec.js
+++ b/e2e/test/compatibility.cy.spec.js
@@ -173,7 +173,8 @@ describe("Embedding SDK: shoppy compatibility", () => {
 
   // TODO (Kelvin 2026-07-07) bandage, not a fix. Metabase's appdb search-index reindex has a
   // race that can strand a fully-built index as "pending" instead of activating it. Couldn't
-  // land the real backend fix yet (EMB-2059); this forces a reindex and waits for it first.
+  // land the real backend fix yet; this forces a reindex and waits for it first. The actual
+  // backend bug (not EMB-2059, which is just this bandage) hasn't been filed as its own ticket yet.
   // Scoped to just this test, not the whole suite — it's the only one that needs it.
   describe("data picker", () => {
     before(() => {

--- a/e2e/test/compatibility.cy.spec.js
+++ b/e2e/test/compatibility.cy.spec.js
@@ -1,3 +1,5 @@
+import { METABASE_URL, signInAsAdmin } from "../support/helpers/sign-in"
+
 const TIMEOUT = 20000
 
 describe("Embedding SDK: shoppy compatibility", () => {
@@ -169,30 +171,80 @@ describe("Embedding SDK: shoppy compatibility", () => {
     })
   })
 
-  it("should not display tables in the data picker", () => {
-    cy.visit({
-      url: "/admin/analytics/new/from-scratch",
+  // TODO (Kelvin 2026-07-07) bandage, not a fix. Metabase's appdb search-index reindex has a
+  // race that can strand a fully-built index as "pending" instead of activating it. Couldn't
+  // land the real backend fix yet (EMB-2059); this forces a reindex and waits for it first.
+  // Scoped to just this test, not the whole suite — it's the only one that needs it.
+  describe("data picker", () => {
+    before(() => {
+      const REINDEX_POLL_INTERVAL_MS = 1000
+      const REINDEX_POLL_MAX_ATTEMPTS = 60
+
+      function waitForDatasetIndex(sessionId, attempt = 0) {
+        cy.request({
+          method: "GET",
+          url: `${METABASE_URL}/api/search?models=dataset`,
+          headers: { "X-Metabase-Session": sessionId },
+        }).then(({ body }) => {
+          if (body.total > 0) {
+            return
+          }
+          if (attempt >= REINDEX_POLL_MAX_ATTEMPTS) {
+            // Fail loudly here instead of silently proceeding into a doomed test — a confusing
+            // "can't find Orders" UI assertion failure downstream is much harder to diagnose than
+            // this being the actual problem.
+            throw new Error(
+              `waitForDatasetIndex: no datasets found after ${attempt} attempts`,
+            )
+          }
+
+          cy.wait(REINDEX_POLL_INTERVAL_MS)
+          waitForDatasetIndex(sessionId, attempt + 1)
+        })
+      }
+
+      signInAsAdmin().then((sessionId) => {
+        cy.request({
+          method: "POST",
+          url: `${METABASE_URL}/api/search/force-reindex`,
+          headers: { "X-Metabase-Session": sessionId },
+          failOnStatusCode: false,
+        })
+
+        waitForDatasetIndex(sessionId)
+      })
     })
 
-    cy.get("main").within(() => {
-      cy.findByText("Pick your starting data", { timeout: TIMEOUT }).should(
-        "exist",
-      )
-    })
+    it("should not display tables in the data picker", () => {
+      cy.visit({
+        url: "/admin/analytics/new/from-scratch",
+      })
 
-    cy.get("[data-element-id=mantine-popover]", {
-      timeout: TIMEOUT,
-    }).within(() => {
-      cy.log("should contain only a single model without any duplicate tables")
-      cy.findAllByText("Orders", { timeout: TIMEOUT }).should("have.length", 1)
-      cy.findAllByText("Orders + Products", { timeout: TIMEOUT }).should(
-        "have.length",
-        1,
-      )
-      cy.findAllByText("Products", { timeout: TIMEOUT }).should(
-        "have.length",
-        1,
-      )
+      cy.get("main").within(() => {
+        cy.findByText("Pick your starting data", { timeout: TIMEOUT }).should(
+          "exist",
+        )
+      })
+
+      cy.get("[data-element-id=mantine-popover]", {
+        timeout: TIMEOUT,
+      }).within(() => {
+        cy.log(
+          "should contain only a single model without any duplicate tables",
+        )
+        cy.findAllByText("Orders", { timeout: TIMEOUT }).should(
+          "have.length",
+          1,
+        )
+        cy.findAllByText("Orders + Products", { timeout: TIMEOUT }).should(
+          "have.length",
+          1,
+        )
+        cy.findAllByText("Products", { timeout: TIMEOUT }).should(
+          "have.length",
+          1,
+        )
+      })
     })
   })
 })


### PR DESCRIPTION
EMB-2059: https://linear.app/metabase/issue/EMB-2059

## Summary

Metabase's appdb search-index reindex has a race that can strand a fully-built index as "pending" instead of activating it, leaving Models (e.g. "Orders", "Products") unsearchable after a fresh DB restore. This intermittently breaks `compatibility.cy.spec.js`'s "should not display tables in the data picker" test — the data picker shows an empty state because search hasn't actually finished indexing yet.

This is just a bandage — a proper fix can't be made currently.

## Root cause

This happens on a specific combination — a Metabase jar plus a restored data dump. After metabase/metabase#76551, an unrelated startup task (loading built-in Usage Analytics content) started blocking for several seconds during boot instead of running in the background. That delay causes two search-index build tasks to run at nearly the same time instead of one after another, and the index effectively gets stuck as a result — one copy ends up fully built but never marked active, the other gets marked active empty.

### How to verify

Shoppy's own CI (`MB_RUN_MODE: dev`) doesn't reliably reproduce this — the race only shows up reliably when Metabase's own e2e orchestration runs it (`MB_RUN_MODE: e2e`, the same setup used by `e2e-shoppy-tests` in the metabase repo's CI). Verify from a `metabase/metabase` checkout instead:

1. Build an EE jar:
   ```bash
   MB_EDITION=ee ./bin/build.sh
   ```
2. Build the embedding SDK package (the sample-app flow copies this in, and will fail with `ENOENT ... resources/embedding-sdk` without it):
   ```bash
   bun run build-embedding-sdk-package
   ```
3. Keep this running in a separate terminal — it builds the actual SDK bundle content the package loads at runtime:
   ```bash
   MB_EDITION=ee bun run build-hot
   ```
4. Get the Shoppy Postgres app-db dump (one-time, real coredev instance) — enable Tailscale, log in with your work email, credentials in 1Password under "Shoppy Coredev Appdb":
   ```bash
   pg_dump "postgres://{username}:{password}@{host}:{port}/{database}" > ./e2e/tmp/db_dumps/shoppy_metabase_app_db_dump.sql
   ```
5. Run the suite pointed at this branch, in GUI mode:
   ```bash
   SAMPLE_APP_BRANCH_NAME=emb-2059-force-reindex-before-tests \
   MB_EDITION=ee MB_RUN_MODE=e2e SDK_TEST_SUITE=shoppy-e2e SAMPLE_APP_ENVIRONMENT=production \
   ENTERPRISE_TOKEN=<token> METASTORE_DEV_SERVER_URL=https://token-check.staging.metabase.com \
   CYPRESS_GUI=true \
   bun run test-cypress-host-sample-apps
   ```
   `SAMPLE_APP_BRANCH_NAME` overrides the `main`-branch default the runner otherwise fetches Shoppy from. `METASTORE_DEV_SERVER_URL` matters here — without it, token/license validation silently fails against the wrong endpoint and every premium feature (including JWT SSO) reads as disabled, which looks like an unrelated "SSO has not been enabled" error. Full local-setup details: `enterprise/frontend/src/embedding-sdk-package/dev.md` in the metabase repo ("Sample Apps compatibility with Embedding SDK tests").
6. Compare against `main` (no fix) to confirm the bug is real — same command as step 5, but:
   ```bash
   SAMPLE_APP_BRANCH_NAME=main \
   MB_EDITION=ee MB_RUN_MODE=e2e SDK_TEST_SUITE=shoppy-e2e SAMPLE_APP_ENVIRONMENT=production \
   ENTERPRISE_TOKEN=<token> METASTORE_DEV_SERVER_URL=https://token-check.staging.metabase.com \
   CYPRESS_GUI=true \
   bun run test-cypress-host-sample-apps
   ```
   This should intermittently fail "should not display tables in the data picker" on a fresh restore, while step 5 (this branch) passes.